### PR TITLE
Update CommentsList.ascx.cs

### DIFF
--- a/Website/layouts/WeBlog/CommentsList.ascx.cs
+++ b/Website/layouts/WeBlog/CommentsList.ascx.cs
@@ -13,6 +13,13 @@ namespace Sitecore.Modules.WeBlog.Layouts
             LoadComments();
             Sitecore.Events.Event.Subscribe(Constants.Events.UI.COMMENT_ADDED, new EventHandler(this.CommentAdded));
         }
+        
+        public override void Dispose()
+        {
+            // without unsubscribing there will be a memory leak from the subscription in the Page_Load event.
+            Sitecore.Events.Event.Unsubscribe(Constants.Events.UI.COMMENT_ADDED, new EventHandler(this.CommentAdded));
+        } 
+        
 
         protected virtual void LoadComments()
         {


### PR DESCRIPTION
We had a serious memory leak on our project and tracked it down to the CommentsList sublayout.  As mentioned in the note, when subscribing to an event in on_load it is important to unsubscribe in the dispose() method or else garbage collection will have trouble deallocating the memory for this control.

Fixing memory leak by unsubscribing from event in the Dispose() method.
http://adeneys.wordpress.com/2009/02/24/warning-memory-leaks-ahead/
