### PR TITLE
Hide comment count on blog entry list

### DIFF
--- a/Website/layouts/WeBlog/PostListEntry.ascx
+++ b/Website/layouts/WeBlog/PostListEntry.ascx
@@ -12,7 +12,7 @@
             <%# GetSummary(((ListViewDataItem)Container).DataItem as EntryItem)%>
             
             <asp:HyperLink ID="BlogPostLink" runat="server" CssClass="wb-read-more" NavigateUrl='<%# Eval("Url") %>'><%#Sitecore.Modules.WeBlog.Globalization.Translator.Text("READ_MORE")%></asp:HyperLink>
-            <span class="wb-comment-count" runat="server" Visible="<%# !(((ListViewDataItem)Container).DataItem as EntryItem).DisableComments %>">
+            <span class="wb-comment-count" runat="server" Visible="<%# (((ListViewDataItem)Container).DataItem as EntryItem).CommentCount > 0 || !(((ListViewDataItem)Container).DataItem as EntryItem).DisableComments.Checked %>">
                 <%#Sitecore.Modules.WeBlog.Globalization.Translator.Render("COMMENTS")%> (<%#(((ListViewDataItem)Container).DataItem as EntryItem).CommentCount%>)
             </span>
         </div>


### PR DESCRIPTION
I noticed that even when comments were disabled, the blog entry list would show the number of comments.

This pull request will hide the comment count on the blog entry list if comments are disabled and there are no comments on the entry.
