### PR TITLE
#75 | Cannot rebuild WeBlog index (root item cannot be found)

### DIFF
--- a/Website/App_Config/Include/WeBlog.ContentSearch.config
+++ b/Website/App_Config/Include/WeBlog.ContentSearch.config
@@ -24,7 +24,7 @@
             <locations hint="list:AddCrawler">
               <crawler type="Sitecore.ContentSearch.SitecoreItemCrawler, Sitecore.ContentSearch">
                 <Database>web</Database>
-                <Root>/sitecore/content/Home/Blog</Root>
+                <Root>/sitecore/content/Home</Root>
               </crawler>
             </locations>
           </index>


### PR DESCRIPTION
Fix: #75