### PR TITLE
#77 | Cannot see posts from master database in PageEditor

### DIFF
--- a/Website/App_Config/Include/WeBlog.ContentSearch.config
+++ b/Website/App_Config/Include/WeBlog.ContentSearch.config
@@ -24,8 +24,12 @@
             <locations hint="list:AddCrawler">
               <crawler type="Sitecore.ContentSearch.SitecoreItemCrawler, Sitecore.ContentSearch">
                 <Database>web</Database>
-                <Root>/sitecore/content/Home/Blog</Root>
+                <Root>/sitecore/content/Home</Root>
               </crawler>
+              <crawler type="Sitecore.ContentSearch.SitecoreItemCrawler, Sitecore.ContentSearch">
+                <Database>master</Database>
+                <Root>/sitecore/content/Home</Root>
+              </crawler>			  
             </locations>
           </index>
         </indexes>
@@ -46,7 +50,7 @@
               <!-- Need this field see http://stackoverflow.com/questions/23140889/sitecore-contentsearch-duplicate-indexes-when-saving-items-->
               <field fieldName="_uniqueid"            storageType="YES" indexType="TOKENIZED"    vectorType="NO" boost="1f" type="System.String" settingType="Sitecore.ContentSearch.LuceneProvider.LuceneSearchFieldConfiguration, Sitecore.ContentSearch.LuceneProvider">
                 <analyzer type="Sitecore.ContentSearch.LuceneProvider.Analyzers.LowerCaseKeywordAnalyzer, Sitecore.ContentSearch.LuceneProvider" />
-              </field>             
+              </field>
             </fieldNames>
           </fieldMap>
           <include hint="list:IncludeTemplate">

--- a/Website/Managers/CommentManager.cs
+++ b/Website/Managers/CommentManager.cs
@@ -257,6 +257,7 @@ namespace Sitecore.Modules.WeBlog.Managers
                             var builder = PredicateBuilder.True<CommentResultItem>();
                             builder = builder.And(i => i.Path.Contains(item.Paths.FullPath));
                             builder = builder.And(i => i.TemplateId == Settings.CommentTemplateID);
+                            builder = builder.And(i => i.DatabaseName.Equals(Context.Database.Name, StringComparison.InvariantCulture));
                             var indexresults = context.GetQueryable<CommentResultItem>().Where(builder);
                             if (indexresults.Any())
                             {

--- a/Website/Managers/EntryManager.cs
+++ b/Website/Managers/EntryManager.cs
@@ -248,7 +248,7 @@ namespace Sitecore.Modules.WeBlog.Managers
                 {
                     var builder = PredicateBuilder.True<EntryResultItem>();
                     var id = Settings.EntryTemplateID;
-                    builder = builder.And(i => i.TemplateId==id);
+                    builder = builder.And(i => i.TemplateId == id);
                     // Tag
                     if (!String.IsNullOrEmpty(tag))
                     {
@@ -259,6 +259,7 @@ namespace Sitecore.Modules.WeBlog.Managers
                     {
                         builder = builder.And(PredicateController.BlogCategory(category));
                     }
+                    builder = builder.And(item => item.DatabaseName.Equals(Context.Database.Name, StringComparison.InvariantCulture));
                     var indexresults = context.GetQueryable<EntryResultItem>().Where(builder);
                     if (indexresults.Any())
                     {


### PR DESCRIPTION
**Reason:** Currently there is only one crawler defined

```
<crawler type="Sitecore.ContentSearch.SitecoreItemCrawler, Sitecore.ContentSearch">
    <Database>web</Database>
    <Root>/sitecore/content/Home</Root>
</crawler>
```

**Solution:**
I don't think WeBlog needs separate indexes for master and web, so I've decided to just add new crawler for master DB and append extra predicate.