### PR TITLE
#79 | Content Search for Sitecore 7.0 is not working.

### DIFF
--- a/Website/App_Config/Include/WeBlog.ContentSearch.SC70.config
+++ b/Website/App_Config/Include/WeBlog.ContentSearch.SC70.config
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0"?>
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
+  <sitecore>
+    <contentSearch>
+      <configuration type="Sitecore.ContentSearch.LuceneProvider.LuceneSearchConfiguration, Sitecore.ContentSearch.LuceneProvider">
+        <indexes hint="list:AddIndex">
+          <index id="WeBlog" type="Sitecore.ContentSearch.LuceneProvider.LuceneIndex, Sitecore.ContentSearch.LuceneProvider">
+            <param desc="name">$(id)</param>
+            <param desc="folder">$(id)</param>
+            <!-- This initializes index property store. Id has to be set to the index id -->
+            <param desc="propertyStore" ref="contentSearch/databasePropertyStore" param1="$(id)" />
+            <configuration ref="contentSearch/indexConfigurations/WeBlogSearchConfiguration" />
+            <strategies hint="list:AddStrategy">
+              <!-- NOTE: order of these is controls the execution order -->
+              <strategy ref="contentSearch/indexUpdateStrategies/rebuildAfterFullPublish" />
+              <strategy ref="contentSearch/indexUpdateStrategies/onPublishEndAsync" />
+              <strategy ref="contentSearch/indexUpdateStrategies/remoteRebuild" />
+            </strategies>
+            <commitPolicyExecutor type="Sitecore.ContentSearch.CommitPolicyExecutor, Sitecore.ContentSearch">
+              <policies hint="list:AddCommitPolicy">
+                <policy type="Sitecore.ContentSearch.TimeIntervalCommitPolicy, Sitecore.ContentSearch" />
+              </policies>
+            </commitPolicyExecutor>
+            <locations hint="list:AddCrawler">
+              <crawler type="Sitecore.ContentSearch.SitecoreItemCrawler, Sitecore.ContentSearch">
+                <Database>master</Database>
+                <Root>/sitecore/content/Home</Root>
+              </crawler>
+              <crawler type="Sitecore.ContentSearch.SitecoreItemCrawler, Sitecore.ContentSearch">
+                <Database>web</Database>
+                <Root>/sitecore/content/Home</Root>
+              </crawler>
+            </locations>
+          </index>
+        </indexes>
+      </configuration>
+      <indexConfigurations>
+        <WeBlogSearchConfiguration type="Sitecore.ContentSearch.LuceneProvider.LuceneIndexConfiguration, Sitecore.ContentSearch.LuceneProvider">
+          <indexAllFields>true</indexAllFields>
+          <analyzer ref="contentSearch/configuration/defaultIndexConfiguration/analyzer" />
+          <fieldMap type="Sitecore.ContentSearch.FieldMap, Sitecore.ContentSearch">
+            <fieldNames hint="raw:AddFieldByFieldName">
+              <field fieldName="Tags" storageType="YES" indexType="TOKENIZED"    vectorType="NO" boost="1f" type="System.String" settingType="Sitecore.ContentSearch.LuceneProvider.LuceneSearchFieldConfiguration, Sitecore.ContentSearch.LuceneProvider">
+                <analyzer type="Sitecore.ContentSearch.LuceneProvider.Analyzers.LowerCaseKeywordAnalyzer, Sitecore.ContentSearch.LuceneProvider" />
+              </field>
+              <field fieldName="Category" storageType="YES" indexType="TOKENIZED"    vectorType="NO" boost="1f" type="System.String" settingType="Sitecore.ContentSearch.LuceneProvider.LuceneSearchFieldConfiguration, Sitecore.ContentSearch.LuceneProvider">
+                <analyzer type="Sitecore.ContentSearch.LuceneProvider.Analyzers.LowerCaseKeywordAnalyzer, Sitecore.ContentSearch.LuceneProvider" />
+              </field>
+              <!-- Need this field see http://stackoverflow.com/questions/23140889/sitecore-contentsearch-duplicate-indexes-when-saving-items-->
+              <field fieldName="_uniqueid"            storageType="YES" indexType="TOKENIZED"    vectorType="NO" boost="1f" type="System.String" settingType="Sitecore.ContentSearch.LuceneProvider.LuceneSearchFieldConfiguration, Sitecore.ContentSearch.LuceneProvider">
+                <analyzer type="Sitecore.ContentSearch.LuceneProvider.Analyzers.LowerCaseKeywordAnalyzer, Sitecore.ContentSearch.LuceneProvider" />
+              </field>
+            </fieldNames>
+          </fieldMap>
+          <include hint="list:IncludeTemplate">
+            <BlogEntry>{5FA92FF4-4AC2-48E2-92EB-E1E4914677B0}</BlogEntry>
+            <BlogComment>{70949D4E-35D8-4581-A7A2-52928AA119D5}</BlogComment>
+          </include>
+          <fieldReaders ref="contentSearch/configuration/defaultIndexConfiguration/fieldReaders"/>
+          <indexFieldStorageValueFormatter ref="contentSearch/configuration/defaultIndexConfiguration/indexFieldStorageValueFormatter"/>
+          <indexDocumentPropertyMapper ref="contentSearch/configuration/defaultIndexConfiguration/indexDocumentPropertyMapper"/>
+        </WeBlogSearchConfiguration>
+      </indexConfigurations>
+    </contentSearch>
+  </sitecore>
+</configuration>

--- a/Website/Sitecore.Modules.WeBlog.csproj
+++ b/Website/Sitecore.Modules.WeBlog.csproj
@@ -451,7 +451,7 @@
     <Content Include="sitecore modules\Shell\CustomItemGenerator\Nvelocity Templates\CustomItem.base.vm" />
     <Content Include="sitecore modules\Shell\CustomItemGenerator\Nvelocity Templates\CustomItem.partial.vm" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="!$(Configuration.Contains('sc7.0'))">
     <Content Include="App_Config\Include\WeBlog.ContentSearch.config">
       <SubType>Designer</SubType>
     </Content>
@@ -462,6 +462,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="App_Config\Include\WeBlog.Search.config" />
+  </ItemGroup>
+  <ItemGroup Condition="$(Configuration.Contains('sc7.0'))">
+    <Content Include="App_Config\Include\WeBlog.ContentSearch.SC70.config" />      
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />


### PR DESCRIPTION
* WeBlog index cannot be found because there is not way to create it (rebuild)

* WeBlog index cannot be created because configuration is not compatible with Sitecore 7.0, thus it is not visible under *Indexing Manager* window.

Some changes:
* Following property is not available for SC7.0
```
<initializeOnAdd>true</initializeOnAdd>
```
* Different node hierarchy

**SC75** 
```
contentSearch/indexConfigurations/indexUpdateStrategies/rebuildAfterFullPublish
```
**SC70**
```
contentSearch/indexUpdateStrategies/rebuildAfterFullPublish
```

Maybe there is more elegant solution for that, but this is my first idea. 
The same configs cannot be included as there is problem with different node hierarchy in ContentSearch.

*Notice:*
This commit is related to #77 . It uses the same strategy for defining 2 crawlers per 1 index and then filtering results with DB predicate.