### PR TITLE
#81 | WeBlog buttons from the ribbon are not visible in Sitecore 8.

### DIFF
--- a/Website/App_Config/Include/WeBlog.ExperienceEditor.config
+++ b/Website/App_Config/Include/WeBlog.ExperienceEditor.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0"?>
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
+  <sitecore>
+    <sitecore.experienceeditor.speak.requests>
+      <request name="ExperienceEditor.WeBlog.GenerateFieldEditorUrl" type="Sitecore.Modules.WeBlog.ExperienceEditor.GenerateFieldEditorUrl, Sitecore.Modules.WeBlog"/>
+      <request name="ExperienceEditor.WeBlog.GetCurrentBlogId" type="Sitecore.Modules.WeBlog.ExperienceEditor.GetCurrentBlogId, Sitecore.Modules.WeBlog"/>
+      <request name="ExperienceEditor.WeBlog.NewEntry" type="Sitecore.Modules.WeBlog.ExperienceEditor.NewEntry, Sitecore.Modules.WeBlog"/>
+      <request name="ExperienceEditor.WeBlog.NewCategory" type="Sitecore.Modules.WeBlog.ExperienceEditor.NewCategory, Sitecore.Modules.WeBlog"/>
+      <request name="ExperienceEditor.WeBlog.CanExecuteWeBlogCommands" type="Sitecore.Modules.WeBlog.ExperienceEditor.CanExecuteWeBlogCommands, Sitecore.Modules.WeBlog"/>
+      <request name="ExperienceEditor.WeBlog.IsEntryItem" type="Sitecore.Modules.WeBlog.ExperienceEditor.IsEntryItem, Sitecore.Modules.WeBlog"/>
+    </sitecore.experienceeditor.speak.requests>
+  </sitecore>
+</configuration>

--- a/Website/ExperienceEditor/CanExecuteWeBlogCommands.cs
+++ b/Website/ExperienceEditor/CanExecuteWeBlogCommands.cs
@@ -1,0 +1,20 @@
+﻿using Sitecore.Modules.WeBlog.Managers;
+using Sitecore.ExperienceEditor.Speak.Server.Contexts;
+using Sitecore.ExperienceEditor.Speak.Server.Requests;
+using Sitecore.ExperienceEditor.Speak.Server.Responses;
+
+namespace Sitecore.Modules.WeBlog.ExperienceEditor
+{
+    public class CanExecuteWeBlogCommands : PipelineProcessorRequest<ItemContext>
+    {
+        public override PipelineProcessorResponseValue ProcessRequest()
+        {
+            var currentItem = RequestContext.Item;
+            var currentBlog = ManagerFactory.BlogManagerInstance.GetCurrentBlog(currentItem);
+            return new PipelineProcessorResponseValue
+            {
+                Value = currentBlog != null
+            };
+        }
+    }
+}

--- a/Website/ExperienceEditor/GenerateFieldEditorUrl.cs
+++ b/Website/ExperienceEditor/GenerateFieldEditorUrl.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using Sitecore.Data;
+using Sitecore.Shell.Applications.ContentEditor;
+using Sitecore.Text;
+using Sitecore.ExperienceEditor.Speak.Server.Contexts;
+using Sitecore.ExperienceEditor.Speak.Server.Requests;
+using Sitecore.ExperienceEditor.Speak.Server.Responses;
+
+namespace Sitecore.Modules.WeBlog.ExperienceEditor
+{
+    public class GenerateFieldEditorUrl : PipelineProcessorRequest<ItemContext>
+    {
+        public string GenerateUrl()
+        {
+            var fieldList = CreateFieldDescriptors(RequestContext.Argument);
+            var fieldeditorOption = new FieldEditorOptions(fieldList);
+            fieldeditorOption.SaveItem = true;
+            return fieldeditorOption.ToUrlString().ToString();
+        }
+
+        private List<FieldDescriptor> CreateFieldDescriptors(string fields)
+        {
+            var fieldList = new List<FieldDescriptor>();
+            var fieldString = new ListString(fields);
+            foreach (string field in new ListString(fieldString))
+                fieldList.Add(new FieldDescriptor(RequestContext.Item, field));
+            return fieldList;
+        }
+
+        public override PipelineProcessorResponseValue ProcessRequest()
+        {
+            return new PipelineProcessorResponseValue
+            {
+                Value = GenerateUrl()
+            };
+        }
+    }
+}

--- a/Website/ExperienceEditor/GetCurrentBlogId.cs
+++ b/Website/ExperienceEditor/GetCurrentBlogId.cs
@@ -1,0 +1,18 @@
+﻿using Sitecore.Modules.WeBlog.Managers;
+using Sitecore.ExperienceEditor.Speak.Server.Contexts;
+using Sitecore.ExperienceEditor.Speak.Server.Requests;
+using Sitecore.ExperienceEditor.Speak.Server.Responses;
+
+namespace Sitecore.Modules.WeBlog.ExperienceEditor
+{
+    public class GetCurrentBlogId : PipelineProcessorRequest<ItemContext>
+    {
+        public override PipelineProcessorResponseValue ProcessRequest()
+        {
+            return new PipelineProcessorResponseValue
+            {
+                Value = ManagerFactory.BlogManagerInstance.GetCurrentBlog(RequestContext.Item).ID.Guid
+            };
+        }
+    }
+}

--- a/Website/ExperienceEditor/IsEntryItem.cs
+++ b/Website/ExperienceEditor/IsEntryItem.cs
@@ -1,0 +1,19 @@
+﻿using Sitecore.ExperienceEditor.Speak.Server.Contexts;
+using Sitecore.ExperienceEditor.Speak.Server.Requests;
+using Sitecore.ExperienceEditor.Speak.Server.Responses;
+using Sitecore.Modules.WeBlog.Extensions;
+
+namespace Sitecore.Modules.WeBlog.ExperienceEditor
+{
+    public class IsEntryItem : PipelineProcessorRequest<ItemContext>
+    {
+        public override PipelineProcessorResponseValue ProcessRequest()
+        {
+            return new PipelineProcessorResponseValue
+            {
+                Value = RequestContext.Item.TemplateIsOrBasedOn(Settings.EntryTemplateID)
+            };
+        }
+
+    }
+}

--- a/Website/ExperienceEditor/NewCategory.cs
+++ b/Website/ExperienceEditor/NewCategory.cs
@@ -1,0 +1,36 @@
+﻿using Sitecore.Data;
+using Sitecore.Data.Managers;
+using Sitecore.Modules.WeBlog.Managers;
+using Sitecore.ExperienceEditor.Speak.Server.Contexts;
+using Sitecore.ExperienceEditor.Speak.Server.Requests;
+using Sitecore.ExperienceEditor.Speak.Server.Responses;
+
+namespace Sitecore.Modules.WeBlog.ExperienceEditor
+{
+    public class NewCategory : PipelineProcessorRequest<ItemContext>
+    {
+        public override PipelineProcessorResponseValue ProcessRequest()
+        {
+            var itemTitle = RequestContext.Argument;
+            var currentItem = RequestContext.Item;
+            var currentBlog = ManagerFactory.BlogManagerInstance.GetCurrentBlog(currentItem);
+            if (currentBlog != null)
+            {
+                var template = new TemplateID(currentBlog.BlogSettings.CategoryTemplateID);
+                var categories = ManagerFactory.CategoryManagerInstance.GetCategoryRoot(currentItem);
+                var newItem = ItemManager.AddFromTemplate(itemTitle, template, categories);
+
+                ContentHelper.PublishItem(newItem);
+
+                return new PipelineProcessorResponseValue
+                {
+                    Value = newItem.ID.Guid
+                };
+            }
+            return new PipelineProcessorResponseValue
+            {
+                Value = null
+            };
+        }
+    }
+}

--- a/Website/ExperienceEditor/NewEntry.cs
+++ b/Website/ExperienceEditor/NewEntry.cs
@@ -1,0 +1,36 @@
+﻿using Sitecore.Data;
+using Sitecore.Data.Items;
+using Sitecore.Data.Managers;
+using Sitecore.Modules.WeBlog.Managers;
+using Sitecore.ExperienceEditor.Speak.Server.Contexts;
+using Sitecore.ExperienceEditor.Speak.Server.Requests;
+using Sitecore.ExperienceEditor.Speak.Server.Responses;
+
+namespace Sitecore.Modules.WeBlog.ExperienceEditor
+{
+    public class NewEntry : PipelineProcessorRequest<ItemContext>
+    {
+        public override PipelineProcessorResponseValue ProcessRequest()
+        {
+            var itemTitle = RequestContext.Argument;
+            var currentItem = RequestContext.Item;
+            var currentBlog = ManagerFactory.BlogManagerInstance.GetCurrentBlog(currentItem);
+            if (currentBlog != null)
+            {
+                var template = new TemplateID(currentBlog.BlogSettings.EntryTemplateID);
+                Item newItem = ItemManager.AddFromTemplate(itemTitle, template, currentBlog);
+
+                ContentHelper.PublishItem(newItem);
+
+                return new PipelineProcessorResponseValue
+                {
+                    Value = newItem.ID.Guid
+                };
+            }
+            return new PipelineProcessorResponseValue
+            {
+                Value = null
+            };
+        }
+    }
+}

--- a/Website/Sitecore.Modules.WeBlog.csproj
+++ b/Website/Sitecore.Modules.WeBlog.csproj
@@ -94,6 +94,9 @@
       <HintPath>$(SitecorePath)\bin\Sitecore.ExperienceEditor.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Sitecore.ExperienceEditor.Speak" Condition="$(DefineConstants.Contains('FEATURE_EXPERIENCE_EDITOR'))">
+      <HintPath>$(SitecorePath)\bin\Sitecore.ExperienceEditor.Speak.dll</HintPath>
+    </Reference>
     <Reference Include="Sitecore.Kernel">
       <HintPath>$(SitecorePath)\bin\Sitecore.Kernel.dll</HintPath>
       <Private>False</Private>
@@ -128,6 +131,14 @@
     <Compile Include="Buckets\SimpleCreationDateBucketFolderPath.cs" />
     <Compile Include="Search\SearchTypes\CommentResultItem.cs" />
     <Compile Include="Search\SearchTypes\EntryResultItem.cs" />
+  </ItemGroup>
+  <ItemGroup  Condition="$(DefineConstants.Contains('FEATURE_EXPERIENCE_EDITOR'))">
+    <Compile Include="ExperienceEditor\CanExecuteWeBlogCommands.cs" />
+    <Compile Include="ExperienceEditor\IsEntryItem.cs" />
+    <Compile Include="ExperienceEditor\NewCategory.cs" />
+    <Compile Include="ExperienceEditor\NewEntry.cs" />
+    <Compile Include="ExperienceEditor\GetCurrentBlogId.cs" />
+    <Compile Include="ExperienceEditor\GenerateFieldEditorUrl.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BlogSettings.cs" />
@@ -435,6 +446,12 @@
       <SubType>Designer</SubType>
     </Content>
   </ItemGroup>
+  <ItemGroup Condition="$(DefineConstants.Contains('FEATURE_EXPERIENCE_EDITOR'))">
+    <Content Include="sitecore\shell\client\WeBlog\ExperienceEditor\Commands\NewCategory.js" />
+    <Content Include="sitecore\shell\client\WeBlog\ExperienceEditor\Commands\NewEntry.js" />
+    <Content Include="sitecore\shell\client\WeBlog\ExperienceEditor\Commands\EditEntrySettings.js" />
+    <Content Include="sitecore\shell\client\WeBlog\ExperienceEditor\Commands\EditBlogSettings.js" />
+  </ItemGroup>  
   <ItemGroup>
     <Content Include="How to build.txt" />
   </ItemGroup>
@@ -462,6 +479,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="App_Config\Include\WeBlog.Search.config" />
+  </ItemGroup>
+  <ItemGroup Condition="$(DefineConstants.Contains('FEATURE_EXPERIENCE_EDITOR'))">
+    <Content Include="App_Config\Include\WeBlog.ExperienceEditor.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/Website/sitecore/shell/client/WeBlog/ExperienceEditor/Commands/EditBlogSettings.js
+++ b/Website/sitecore/shell/client/WeBlog/ExperienceEditor/Commands/EditBlogSettings.js
@@ -1,0 +1,24 @@
+﻿define(["sitecore"], function (Sitecore) {
+    Sitecore.Commands.EditBlogSettings = {
+        canExecute: function (context) {
+            var key = "CanExecuteWeBlogCommands";
+            if (Sitecore[key] == undefined) {
+                Sitecore[key] = context.app.canExecute("ExperienceEditor.WeBlog.CanExecuteWeBlogCommands", context.currentContext);
+            }
+            return Sitecore[key];
+        },
+        execute: function (context) {
+            Sitecore.ExperienceEditor.PipelinesUtil.generateRequestProcessor("ExperienceEditor.WeBlog.GetCurrentBlogId", function (response1) {
+                context.currentContext.itemId = response1.responseValue.value;
+                var fields = "Title|Email|Theme|DisplayItemCount|DisplayCommentSidebarCount|Maximum Entry Image Size|Maximum Thumbnail Image Size|Enable RSS|Enable Comments|Show Email Within Comments|EnableLiveWriter|Enable Gravatar|Gravatar Size|Default Gravatar Style|Gravatar Rating|Custom Dictionary Folder";
+                context.currentContext.argument = fields;
+
+                Sitecore.ExperienceEditor.PipelinesUtil.generateRequestProcessor("ExperienceEditor.WeBlog.GenerateFieldEditorUrl", function (response) {
+                    var dialogUrl = response.responseValue.value;
+                    var dialogFeatures = "dialogHeight: 545px;dialogWidth: 640px;";
+                    Sitecore.ExperienceEditor.Dialogs.showModalDialog(dialogUrl, '', dialogFeatures, null);
+                }).execute(context);
+            }).execute(context);
+        }
+    };
+});

--- a/Website/sitecore/shell/client/WeBlog/ExperienceEditor/Commands/EditEntrySettings.js
+++ b/Website/sitecore/shell/client/WeBlog/ExperienceEditor/Commands/EditEntrySettings.js
@@ -1,0 +1,18 @@
+﻿define(["sitecore"], function (Sitecore) {
+    Sitecore.Commands.EditEntrySettings = {
+        canExecute: function (context) {
+            return context.app.canExecute("ExperienceEditor.WeBlog.IsEntryItem", context.currentContext);
+        },
+        execute: function (context) {
+            var fields = "Category|Tags|Author|Entry Date|Disable comments";
+            context.currentContext.argument = fields;
+
+            Sitecore.ExperienceEditor.PipelinesUtil.generateRequestProcessor("ExperienceEditor.WeBlog.GenerateFieldEditorUrl", function (response) {
+                var dialogUrl = response.responseValue.value;
+                var dialogFeatures = "dialogHeight: 680px;dialogWidth: 520px;";
+                Sitecore.ExperienceEditor.Dialogs.showModalDialog(dialogUrl, '', dialogFeatures, null);
+            }).execute(context);
+
+        }
+    };
+});

--- a/Website/sitecore/shell/client/WeBlog/ExperienceEditor/Commands/NewCategory.js
+++ b/Website/sitecore/shell/client/WeBlog/ExperienceEditor/Commands/NewCategory.js
@@ -1,0 +1,21 @@
+﻿define(["sitecore"], function (Sitecore) {
+    Sitecore.Commands.NewCategory = {
+        canExecute: function (context) {
+            var key = "CanExecuteWeBlogCommands";
+            if (Sitecore[key] == undefined) {
+                Sitecore[key] = context.app.canExecute("ExperienceEditor.WeBlog.CanExecuteWeBlogCommands", context.currentContext);
+            }
+            return Sitecore[key];
+        },
+        execute: function (context) {
+            Sitecore.ExperienceEditor.Dialogs.prompt("Enter the name of your new category:", "", function (name) {
+                if (name == null) {
+                    return;
+                }
+                context.currentContext.argument = name;
+                Sitecore.ExperienceEditor.PipelinesUtil.generateRequestProcessor("ExperienceEditor.WeBlog.NewCategory", function (response) {
+                }).execute(context);
+            });
+        }
+    };
+});

--- a/Website/sitecore/shell/client/WeBlog/ExperienceEditor/Commands/NewEntry.js
+++ b/Website/sitecore/shell/client/WeBlog/ExperienceEditor/Commands/NewEntry.js
@@ -1,0 +1,21 @@
+﻿define(["sitecore"], function (Sitecore) {
+    Sitecore.Commands.NewEntry = {
+        canExecute: function (context) {
+            var key = "CanExecuteWeBlogCommands";
+            if (Sitecore[key] == undefined) {
+                Sitecore[key] = context.app.canExecute("ExperienceEditor.WeBlog.CanExecuteWeBlogCommands", context.currentContext);
+            }
+            return Sitecore[key];
+        },
+        execute: function (context) {
+            Sitecore.ExperienceEditor.Dialogs.prompt("Enter the title of your new entry:", "", function (name) {
+                if (name == null) {
+                    return;
+                }
+                context.currentContext.argument = name;
+                Sitecore.ExperienceEditor.PipelinesUtil.generateRequestProcessor("ExperienceEditor.WeBlog.NewEntry", function (response) {
+                }).execute(context);
+            });
+        }
+    };
+});

--- a/data/serialization/core/sitecore/content/Applications/WebEdit/Ribbons/WebEdit/WeBlog.item
+++ b/data/serialization/core/sitecore/content/Applications/WebEdit/Ribbons/WebEdit/WeBlog.item
@@ -10,6 +10,13 @@ template: {EC6D62A5-5D00-4329-8958-8AC1AD100EBB}
 templatekey: Strip
 
 ----field----
+field: {12C1CEB4-F549-472A-97ED-99BFF70EB84E}
+name: ID
+key: id
+content-length: 11
+
+WeBlogStrip
+----field----
 field: {BA3F86A2-4A1C-4D78-B63D-91C2779C1B5E}
 name: __Sortorder
 key: __sortorder
@@ -17,16 +24,16 @@ content-length: 3
 
 125
 ----field----
-field: {12C1CEB4-F549-472A-97ED-99BFF70EB84E}
-name: ID
-key: id
-content-length: 11
+field: {F1A1FE9E-A60C-4DDB-A3A0-BB5B29FE732E}
+name: __Renderings
+key: __renderings
+content-length: 181
 
-WeBlogStrip
+<r>  <d id="{FE5D7FDF-89C0-4D99-9AA3-B5FBD009C9F3}">    <r id="{2AA9FC5A-9F89-4508-A210-5282E9B58468}" par="Id=WeBlogStrip" uid="{E55CA084-BA86-4E4D-9038-64A9A1641845}" />  </d></r>
 ----version----
 language: en
 version: 1
-revision: 6d7cfb70-2946-4015-85ae-5f5ad02f097a
+revision: ca1b7bde-c16c-4246-95a7-026a121461e8
 
 ----field----
 field: {5453DC07-6A17-48BA-8D05-17DB90A2E795}
@@ -62,14 +69,14 @@ name: __Revision
 key: __revision
 content-length: 36
 
-6d7cfb70-2946-4015-85ae-5f5ad02f097a
+ca1b7bde-c16c-4246-95a7-026a121461e8
 ----field----
 field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
 name: __Updated
 key: __updated
 content-length: 34
 
-20111017T164336:634544666160003708
+20150617T193612:635701665728414922
 ----field----
 field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
 name: __Updated by

--- a/data/serialization/core/sitecore/content/Applications/WebEdit/Ribbons/WebEdit/WeBlog/Edit.item
+++ b/data/serialization/core/sitecore/content/Applications/WebEdit/Ribbons/WebEdit/WeBlog/Edit.item
@@ -10,6 +10,13 @@ template: {8F3D8F9B-2D76-4ACE-803F-35415D2B230A}
 templatekey: Chunk
 
 ----field----
+field: {8BB9A5E3-CAE8-49C6-B830-258A51D970C9}
+name: ID
+key: id
+content-length: 9
+
+EditChunk
+----field----
 field: {BA3F86A2-4A1C-4D78-B63D-91C2779C1B5E}
 name: __Sortorder
 key: __sortorder
@@ -17,16 +24,16 @@ content-length: 2
 
 49
 ----field----
-field: {8BB9A5E3-CAE8-49C6-B830-258A51D970C9}
-name: ID
-key: id
-content-length: 9
+field: {F1A1FE9E-A60C-4DDB-A3A0-BB5B29FE732E}
+name: __Renderings
+key: __renderings
+content-length: 189
 
-EditChunk
+<r>   <d id="{FE5D7FDF-89C0-4D99-9AA3-B5FBD009C9F3}">     <r id="{B8CC30CD-725A-4353-9EA6-CD9832CB3996}" par="Id=WeBlogEditChunk" uid="{C2193362-7E78-46DB-9F48-19CD759D37CD}" />   </d> </r>
 ----version----
 language: en
 version: 1
-revision: e0fa2deb-8a01-467b-b89f-16677d89626c
+revision: bdbed865-3cf7-4fb7-b63e-4f036e11620b
 
 ----field----
 field: {C95D21BD-66C3-444B-A37F-D346CBAF2B55}
@@ -62,14 +69,14 @@ name: __Revision
 key: __revision
 content-length: 36
 
-e0fa2deb-8a01-467b-b89f-16677d89626c
+bdbed865-3cf7-4fb7-b63e-4f036e11620b
 ----field----
 field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
 name: __Updated
 key: __updated
 content-length: 34
 
-20081218T222643:633652360033801648
+20150611T212611:635696547711103046
 ----field----
 field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
 name: __Updated by

--- a/data/serialization/core/sitecore/content/Applications/WebEdit/Ribbons/WebEdit/WeBlog/Edit/NewCategory.item
+++ b/data/serialization/core/sitecore/content/Applications/WebEdit/Ribbons/WebEdit/WeBlog/Edit/NewCategory.item
@@ -10,13 +10,6 @@ template: {1DB34C92-03B0-4475-9A39-DA14E4D9D8FC}
 templatekey: Large Button
 
 ----field----
-field: {BA3F86A2-4A1C-4D78-B63D-91C2779C1B5E}
-name: __Sortorder
-key: __sortorder
-content-length: 3
-
-100
-----field----
 field: {D47ED548-84D5-4622-9886-5CC164727507}
 name: Icon
 key: icon
@@ -30,10 +23,24 @@ key: click
 content-length: 16
 
 blog:newcategory
+----field----
+field: {BA3F86A2-4A1C-4D78-B63D-91C2779C1B5E}
+name: __Sortorder
+key: __sortorder
+content-length: 3
+
+100
+----field----
+field: {F1A1FE9E-A60C-4DDB-A3A0-BB5B29FE732E}
+name: __Renderings
+key: __renderings
+content-length: 362
+
+<r>   <d id="{FE5D7FDF-89C0-4D99-9AA3-B5FBD009C9F3}">     <r id="{28D7AA23-A9A3-4ABC-9DE6-AA717F6177CD}" par="Id=NewCategoryButton&amp;Click=trigger%3abutton%3aclick&amp;Command=NewCategory&amp;PageCodeScriptFileName=%2fsitecore%2fshell%2fclient%2fWeBlog%2fExperienceEditor%2fCommands%2fNewCategory.js" uid="{CCC6C8CE-24FB-46DB-B8DB-772506106B9E}" />   </d> </r>
 ----version----
 language: en
 version: 1
-revision: a3b9ea1c-5662-4545-a0be-b0000b1e3b1a
+revision: 7e4cb9b1-b913-4489-96eb-4eb7ec5ebe23
 
 ----field----
 field: {4DF6DA21-E745-444C-956E-1D4A96AB8821}
@@ -76,14 +83,14 @@ name: __Revision
 key: __revision
 content-length: 36
 
-a3b9ea1c-5662-4545-a0be-b0000b1e3b1a
+7e4cb9b1-b913-4489-96eb-4eb7ec5ebe23
 ----field----
 field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
 name: __Updated
 key: __updated
 content-length: 34
 
-20111017T165821:634544675017943487
+20150611T212101:635696544614237812
 ----field----
 field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
 name: __Updated by

--- a/data/serialization/core/sitecore/content/Applications/WebEdit/Ribbons/WebEdit/WeBlog/Edit/NewEntry.item
+++ b/data/serialization/core/sitecore/content/Applications/WebEdit/Ribbons/WebEdit/WeBlog/Edit/NewEntry.item
@@ -10,13 +10,6 @@ template: {1DB34C92-03B0-4475-9A39-DA14E4D9D8FC}
 templatekey: Large Button
 
 ----field----
-field: {BA3F86A2-4A1C-4D78-B63D-91C2779C1B5E}
-name: __Sortorder
-key: __sortorder
-content-length: 3
-
-100
-----field----
 field: {D47ED548-84D5-4622-9886-5CC164727507}
 name: Icon
 key: icon
@@ -30,10 +23,24 @@ key: click
 content-length: 13
 
 blog:newentry
+----field----
+field: {BA3F86A2-4A1C-4D78-B63D-91C2779C1B5E}
+name: __Sortorder
+key: __sortorder
+content-length: 3
+
+100
+----field----
+field: {F1A1FE9E-A60C-4DDB-A3A0-BB5B29FE732E}
+name: __Renderings
+key: __renderings
+content-length: 353
+
+<r>   <d id="{FE5D7FDF-89C0-4D99-9AA3-B5FBD009C9F3}">     <r id="{28D7AA23-A9A3-4ABC-9DE6-AA717F6177CD}" par="Id=NewEntryButton&amp;Click=trigger%3abutton%3aclick&amp;Command=NewEntry&amp;PageCodeScriptFileName=%2fsitecore%2fshell%2fclient%2fWeBlog%2fExperienceEditor%2fCommands%2fNewEntry.js" uid="{30AB8476-4A6C-4C84-ADF1-DDAA5E4FA4B3}" />   </d> </r>
 ----version----
 language: en
 version: 1
-revision: 3dc095e1-19af-424a-9a4c-d071d27d780e
+revision: ede37d7c-ba9b-487b-837b-93defbcdf434
 
 ----field----
 field: {4DF6DA21-E745-444C-956E-1D4A96AB8821}
@@ -76,14 +83,14 @@ name: __Revision
 key: __revision
 content-length: 36
 
-3dc095e1-19af-424a-9a4c-d071d27d780e
+ede37d7c-ba9b-487b-837b-93defbcdf434
 ----field----
 field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
 name: __Updated
 key: __updated
 content-length: 34
 
-20111017T165825:634544675050244753
+20150611T212131:635696544910868671
 ----field----
 field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
 name: __Updated by

--- a/data/serialization/core/sitecore/content/Applications/WebEdit/Ribbons/WebEdit/WeBlog/Settings.item
+++ b/data/serialization/core/sitecore/content/Applications/WebEdit/Ribbons/WebEdit/WeBlog/Settings.item
@@ -10,6 +10,13 @@ template: {8F3D8F9B-2D76-4ACE-803F-35415D2B230A}
 templatekey: Chunk
 
 ----field----
+field: {8BB9A5E3-CAE8-49C6-B830-258A51D970C9}
+name: ID
+key: id
+content-length: 13
+
+SettingsChunk
+----field----
 field: {BA3F86A2-4A1C-4D78-B63D-91C2779C1B5E}
 name: __Sortorder
 key: __sortorder
@@ -17,16 +24,16 @@ content-length: 2
 
 49
 ----field----
-field: {8BB9A5E3-CAE8-49C6-B830-258A51D970C9}
-name: ID
-key: id
-content-length: 13
+field: {F1A1FE9E-A60C-4DDB-A3A0-BB5B29FE732E}
+name: __Renderings
+key: __renderings
+content-length: 193
 
-SettingsChunk
+<r>   <d id="{FE5D7FDF-89C0-4D99-9AA3-B5FBD009C9F3}">     <r id="{B8CC30CD-725A-4353-9EA6-CD9832CB3996}" par="Id=WeBlogSettingsChunk" uid="{C2193362-7E78-46DB-9F48-19CD759D37CD}" />   </d> </r>
 ----version----
 language: en
 version: 1
-revision: fe9c4b79-4f9a-4eb8-8f25-07bf04aee855
+revision: 919357fe-2c8b-4353-a4c6-ebac41f4d267
 
 ----field----
 field: {C95D21BD-66C3-444B-A37F-D346CBAF2B55}
@@ -62,14 +69,14 @@ name: __Revision
 key: __revision
 content-length: 36
 
-fe9c4b79-4f9a-4eb8-8f25-07bf04aee855
+919357fe-2c8b-4353-a4c6-ebac41f4d267
 ----field----
 field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
 name: __Updated
 key: __updated
 content-length: 34
 
-20091102T003059:633927186595354219
+20150611T212526:635696547262519062
 ----field----
 field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
 name: __Updated by

--- a/data/serialization/core/sitecore/content/Applications/WebEdit/Ribbons/WebEdit/WeBlog/Settings/Blog.item
+++ b/data/serialization/core/sitecore/content/Applications/WebEdit/Ribbons/WebEdit/WeBlog/Settings/Blog.item
@@ -10,13 +10,6 @@ template: {1DB34C92-03B0-4475-9A39-DA14E4D9D8FC}
 templatekey: Large Button
 
 ----field----
-field: {BA3F86A2-4A1C-4D78-B63D-91C2779C1B5E}
-name: __Sortorder
-key: __sortorder
-content-length: 3
-
-200
-----field----
 field: {D47ED548-84D5-4622-9886-5CC164727507}
 name: Icon
 key: icon
@@ -30,10 +23,24 @@ key: click
 content-length: 17
 
 blog:blogsettings
+----field----
+field: {BA3F86A2-4A1C-4D78-B63D-91C2779C1B5E}
+name: __Sortorder
+key: __sortorder
+content-length: 3
+
+200
+----field----
+field: {F1A1FE9E-A60C-4DDB-A3A0-BB5B29FE732E}
+name: __Renderings
+key: __renderings
+content-length: 377
+
+<r>   <d id="{FE5D7FDF-89C0-4D99-9AA3-B5FBD009C9F3}">     <r id="{28D7AA23-A9A3-4ABC-9DE6-AA717F6177CD}" par="Id=EditBlogSettingsButton&amp;Click=trigger%3abutton%3aclick&amp;Command=EditBlogSettings&amp;PageCodeScriptFileName=%2fsitecore%2fshell%2fclient%2fWeBlog%2fExperienceEditor%2fCommands%2fEditBlogSettings.js" uid="{2A54193D-DB5E-4EF8-87D9-426E890A9297}" />   </d> </r>
 ----version----
 language: en
 version: 1
-revision: dfdd1dab-e650-4258-b1af-d47efa75b4ed
+revision: b06bfc79-6f43-4d41-8baf-90ccb96fb5f1
 
 ----field----
 field: {4DF6DA21-E745-444C-956E-1D4A96AB8821}
@@ -76,14 +83,14 @@ name: __Revision
 key: __revision
 content-length: 36
 
-dfdd1dab-e650-4258-b1af-d47efa75b4ed
+b06bfc79-6f43-4d41-8baf-90ccb96fb5f1
 ----field----
 field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
 name: __Updated
 key: __updated
 content-length: 34
 
-20111017T165828:634544675088019909
+20150611T212150:635696545109452656
 ----field----
 field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
 name: __Updated by

--- a/data/serialization/core/sitecore/content/Applications/WebEdit/Ribbons/WebEdit/WeBlog/Settings/Entry.item
+++ b/data/serialization/core/sitecore/content/Applications/WebEdit/Ribbons/WebEdit/WeBlog/Settings/Entry.item
@@ -10,13 +10,6 @@ template: {1DB34C92-03B0-4475-9A39-DA14E4D9D8FC}
 templatekey: Large Button
 
 ----field----
-field: {BA3F86A2-4A1C-4D78-B63D-91C2779C1B5E}
-name: __Sortorder
-key: __sortorder
-content-length: 3
-
-200
-----field----
 field: {D47ED548-84D5-4622-9886-5CC164727507}
 name: Icon
 key: icon
@@ -30,10 +23,24 @@ key: click
 content-length: 18
 
 blog:entrysettings
+----field----
+field: {BA3F86A2-4A1C-4D78-B63D-91C2779C1B5E}
+name: __Sortorder
+key: __sortorder
+content-length: 3
+
+200
+----field----
+field: {F1A1FE9E-A60C-4DDB-A3A0-BB5B29FE732E}
+name: __Renderings
+key: __renderings
+content-length: 380
+
+<r>   <d id="{FE5D7FDF-89C0-4D99-9AA3-B5FBD009C9F3}">     <r id="{28D7AA23-A9A3-4ABC-9DE6-AA717F6177CD}" par="Id=EditEntrySettingsButton&amp;Click=trigger%3abutton%3aclick&amp;Command=EditEntrySettings&amp;PageCodeScriptFileName=%2fsitecore%2fshell%2fclient%2fWeBlog%2fExperienceEditor%2fCommands%2fEditEntrySettings.js" uid="{73048829-9559-49E3-87DD-6C9866D9E6DA}" />   </d> </r>
 ----version----
 language: en
 version: 1
-revision: 155e1321-bdf9-4a0c-bc0f-e7f6553e1e41
+revision: 3505e921-198f-4fc3-af81-c912ee450065
 
 ----field----
 field: {4DF6DA21-E745-444C-956E-1D4A96AB8821}
@@ -76,14 +83,14 @@ name: __Revision
 key: __revision
 content-length: 36
 
-155e1321-bdf9-4a0c-bc0f-e7f6553e1e41
+3505e921-198f-4fc3-af81-c912ee450065
 ----field----
 field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
 name: __Updated
 key: __updated
 content-length: 34
 
-20111017T165831:634544675117227046
+20150611T212432:635696546724374531
 ----field----
 field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
 name: __Updated by


### PR DESCRIPTION
WeBlog buttons works fine in **Experience Editor** too from now.
I tested it on SC70, SC75 and SC80. No regression found.