### PR TITLE
Content search support fixes

### DIFF
--- a/Test/test data/entry manager content.xml
+++ b/Test/test data/entry manager content.xml
@@ -97,7 +97,7 @@
                         <content>-0425180743</content>
                     </field>
                   <field tfid="{CBDA26A1-E7E5-437A-9FD7-95EF15810E50}" key="entry date" type="datetime">
-                    <content>20110406T220200:634350457201154960</content>
+                    <content>20110406T220200</content>
                   </field>
                 </fields>
             </version>
@@ -186,7 +186,7 @@
                         <content>-0325180736</content>
                     </field>
                   <field tfid="{CBDA26A1-E7E5-437A-9FD7-95EF15810E50}" key="entry date" type="datetime">
-                    <content>20110306T213952:634350443924226381</content>
+                    <content>20110306T223952</content>
                   </field>
                 </fields>
             </version>
@@ -300,7 +300,7 @@
                         <content>-0325180716</content>
                     </field>
                   <field tfid="{CBDA26A1-E7E5-437A-9FD7-95EF15810E50}" key="entry date" type="datetime">
-                    <content>20110306T220207:634350457276191092</content>
+                    <content>20110306T220207</content>
                   </field>
                 </fields>
             </version>

--- a/Website/Managers/EntryManager.cs
+++ b/Website/Managers/EntryManager.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,8 +8,6 @@ using Sitecore.Diagnostics;
 using Sitecore.Modules.WeBlog.Comparers;
 using Sitecore.Modules.WeBlog.Items.WeBlog;
 using Sitecore.Modules.WeBlog.Extensions;
-using Sitecore.StringExtensions;
-
 
 #if FEATURE_XDB
 using Sitecore.Modules.WeBlog.Analytics.Reporting;
@@ -321,8 +318,8 @@ namespace Sitecore.Modules.WeBlog.Managers
                       if (categoryItem == null)
                           return new EntryItem[0];
 
-                      //var normalizedID = Sitecore.ContentSearch.Utilities.IdHelper.NormalizeGuid(categoryItem.ID);
-                      builder = builder.And(i => i.Category.Contains(categoryItem.ID));
+                      var normalizedID = ContentSearch.Utilities.IdHelper.NormalizeGuid(categoryItem.ID);
+                      builder = builder.And(i => i.Category.Contains(normalizedID));
                         
                     }
 
@@ -337,7 +334,7 @@ namespace Sitecore.Modules.WeBlog.Managers
                     if (indexresults.Any())
                     {
                         result = indexresults.Select(i => new EntryItem(i.GetItem())).ToList();
-                        result = result.OrderBy(post => post.EntryDate.DateTime).Take(maxNumber).ToList();
+                        result = result.OrderByDescending(post => post.EntryDate.DateTime).Take(maxNumber).ToList();
                     }
                 }
             }

--- a/Website/Search/SearchTypes/EntryResultItem.cs
+++ b/Website/Search/SearchTypes/EntryResultItem.cs
@@ -1,6 +1,5 @@
 ﻿using Sitecore.ContentSearch;
 using Sitecore.ContentSearch.SearchTypes;
-using Sitecore.Data;
 
 namespace Sitecore.Modules.WeBlog.Search.SearchTypes
 {
@@ -8,7 +7,7 @@ namespace Sitecore.Modules.WeBlog.Search.SearchTypes
     {
 
         [IndexField("Category")]
-        public ID[] Category { get; set; }
+        public string[] Category { get; set; }
 
         [IndexField("Tags")]
         public string Tags { get; set; }


### PR DESCRIPTION
Hi,

This commit should fix following issues:
* wrong order of returned entries - symptoms below
 * I couldn't see archive component due to wrong posts order
 * post list returned posts in reverse order 

* filtering by category problem
 * I couldn't see any post on the category post list

if you have any questions regarding to changes, do not hesitate to ask. 

p.s
entry manager test suite - green