### PR TITLE
Feature/profanity filter

### DIFF
--- a/Test/Pipelines/ProfanityFilter/FilterWordsTest.cs
+++ b/Test/Pipelines/ProfanityFilter/FilterWordsTest.cs
@@ -1,0 +1,108 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using Sitecore.Modules.WeBlog.Pipelines;
+using Sitecore.Modules.WeBlog.Pipelines.ProfanityFilter;
+
+namespace Sitecore.Modules.WeBlog.Test.Pipelines.ProfanityFilter
+{
+    [TestFixture]
+    [Category("ProfanityFilter FilterWords")]
+    public class FilterWordsTest
+    {
+        [Test]
+        public void Proper_Input_WholeWords()
+        {
+            var processor = new FilterWords();
+            processor.WholeWordsOnly = true;
+            processor.Replacement = "-_-";
+
+            var args = new ProfanityFilterArgs();
+            args.Input = "lorem ipsum";
+            args.WordList = new List<string> {"x", "y"};
+
+            processor.Process(args);
+
+            Assert.AreEqual("lorem ipsum", args.Input);
+        }
+
+        [Test]
+        public void Proper_Input_WholeWords2()
+        {
+            var processor = new FilterWords();
+            processor.WholeWordsOnly = true;
+            processor.Replacement = "-_-";
+
+            var args = new ProfanityFilterArgs();
+            args.Input = "lorem ipsumx";
+            args.WordList = new List<string> { "x", "y" };
+
+            processor.Process(args);
+
+            Assert.AreEqual("lorem ipsumx", args.Input);
+        }
+
+        [Test]
+        public void ImProper_Input_WholeWords()
+        {
+            var processor = new FilterWords();
+            processor.WholeWordsOnly = true;
+            processor.Replacement = "-_-";
+
+            var args = new ProfanityFilterArgs();
+            args.Input = "lorem ipsum x y";
+            args.WordList = new List<string> { "x", "y" };
+
+            processor.Process(args);
+
+            Assert.AreEqual("lorem ipsum -_- -_-", args.Input);
+        }
+
+        [Test]
+        public void ImProper_Input_WholeWords2()
+        {
+            var processor = new FilterWords();
+            processor.WholeWordsOnly = true;
+            processor.Replacement = "-_-";
+
+            var args = new ProfanityFilterArgs();
+            args.Input = "lorem ipsum #x! #y!";
+            args.WordList = new List<string> { "x", "y" };
+
+            processor.Process(args);
+
+            Assert.AreEqual("lorem ipsum #-_-! #-_-!", args.Input);
+        }
+
+        [Test]
+        public void Proper_Input()
+        {
+            var processor = new FilterWords();
+            processor.WholeWordsOnly = false;
+            processor.Replacement = "-_-";
+
+            var args = new ProfanityFilterArgs();
+            args.Input = "lorem ipsum";
+            args.WordList = new List<string> { "x", "y" };
+
+            processor.Process(args);
+
+            Assert.AreEqual("lorem ipsum", args.Input);
+        }
+
+        [Test]
+        public void ImProper_Input()
+        {
+            var processor = new FilterWords();
+            processor.WholeWordsOnly = false;
+            processor.Replacement = "-_-";
+
+            var args = new ProfanityFilterArgs();
+            args.Input = "lorem ipsum xy";
+            args.WordList = new List<string> { "x", "y" };
+
+            processor.Process(args);
+
+            Assert.AreEqual("lorem ipsum -_--_-", args.Input);
+        }
+    }
+}

--- a/Test/Pipelines/ProfanityFilter/ValidateInputTest.cs
+++ b/Test/Pipelines/ProfanityFilter/ValidateInputTest.cs
@@ -1,0 +1,102 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using Sitecore.Modules.WeBlog.Pipelines;
+using Sitecore.Modules.WeBlog.Pipelines.ProfanityFilter;
+
+namespace Sitecore.Modules.WeBlog.Test.Pipelines.ProfanityFilter
+{
+    [TestFixture]
+    [Category("ProfanityFilter ValidateInput")]
+    public class ValidateInputTest
+    {
+        [Test]
+        public void Proper_Input_WholeWords()
+        {
+            var processor = new ValidateInput();
+            processor.WholeWordsOnly = true;
+
+            var args = new ProfanityFilterArgs();
+            args.Input = "lorem ipsum";
+            args.WordList = new List<string> {"x", "y"};
+
+            processor.Process(args);
+
+            Assert.True(args.Valid);
+        }
+
+        [Test]
+        public void Proper_Input_WholeWords2()
+        {
+            var processor = new ValidateInput();
+            processor.WholeWordsOnly = true;
+
+            var args = new ProfanityFilterArgs();
+            args.Input = "lorem ipsumx";
+            args.WordList = new List<string> { "x", "y" };
+
+            processor.Process(args);
+
+            Assert.True(args.Valid);
+        }
+
+        [Test]
+        public void ImProper_Input_WholeWords()
+        {
+            var processor = new ValidateInput();
+            processor.WholeWordsOnly = true;
+
+            var args = new ProfanityFilterArgs();
+            args.Input = "lorem ipsum x y";
+            args.WordList = new List<string> { "x", "y" };
+
+            processor.Process(args);
+
+            Assert.False(args.Valid);
+        }
+
+        [Test]
+        public void ImProper_Input_WholeWords2()
+        {
+            var processor = new ValidateInput();
+            processor.WholeWordsOnly = true;
+
+            var args = new ProfanityFilterArgs();
+            args.Input = "lorem ipsum #x! #y!";
+            args.WordList = new List<string> { "x", "y" };
+
+            processor.Process(args);
+
+            Assert.False(args.Valid);
+        }
+
+        [Test]
+        public void Proper_Input()
+        {
+            var processor = new ValidateInput();
+            processor.WholeWordsOnly = false;
+
+            var args = new ProfanityFilterArgs();
+            args.Input = "lorem ipsum";
+            args.WordList = new List<string> { "x", "y" };
+
+            processor.Process(args);
+
+            Assert.True(args.Valid);
+        }
+
+        [Test]
+        public void ImProper_Input()
+        {
+            var processor = new ValidateInput();
+            processor.WholeWordsOnly = false;
+
+            var args = new ProfanityFilterArgs();
+            args.Input = "lorem ipsum xy";
+            args.WordList = new List<string> { "x", "y" };
+
+            processor.Process(args);
+
+            Assert.False(args.Valid);
+        }
+    }
+}

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -146,6 +146,8 @@
     <Compile Include="Pipelines\GetSummary\AutoGenerateTest.cs" />
     <Compile Include="Pipelines\GetSummary\FirstContentBlockTest.cs" />
     <Compile Include="Pipelines\GetSummary\WrapTest.cs" />
+    <Compile Include="Pipelines\ProfanityFilter\ValidateInputTest.cs" />
+    <Compile Include="Pipelines\ProfanityFilter\FilterWordsTest.cs" />
     <Compile Include="TagManager.cs" />
     <Compile Include="Test.aspx.cs">
       <DependentUpon>Test.aspx</DependentUpon>

--- a/Website/App_Config/Include/WeBlog.config
+++ b/Website/App_Config/Include/WeBlog.config
@@ -15,18 +15,18 @@
             </template>
           </templates>
         </handler>
-          <handler type="Sitecore.Sharedsource.Tasks.NewsMover, Sitecore.Sharedsource.NewsMover" method="OnItemSaved">
-              <database>master</database>
-              <templates hint="raw:AddTemplateConfiguration">
-                  <template id="Modules/WeBlog/MVC/BlogEntry" sort="Descending">
-                      <DateField>Entry Date</DateField>
-                      <YearTemplate formatString="yyyy">Common/Folder</YearTemplate>
-                      <MonthTemplate formatString="MMMM">Common/Folder</MonthTemplate>
-                      <!-- Uncomment the following line if you have too many posts per month (more than 100) -->
-                      <!--<DayTemplate formatString="dd">Common/Folder</DayTemplate>-->
-                  </template>
-              </templates>
-          </handler>
+        <handler type="Sitecore.Sharedsource.Tasks.NewsMover, Sitecore.Sharedsource.NewsMover" method="OnItemSaved">
+          <database>master</database>
+          <templates hint="raw:AddTemplateConfiguration">
+            <template id="Modules/WeBlog/MVC/BlogEntry" sort="Descending">
+              <DateField>Entry Date</DateField>
+              <YearTemplate formatString="yyyy">Common/Folder</YearTemplate>
+              <MonthTemplate formatString="MMMM">Common/Folder</MonthTemplate>
+              <!-- Uncomment the following line if you have too many posts per month (more than 100) -->
+              <!--<DayTemplate formatString="dd">Common/Folder</DayTemplate>-->
+            </template>
+          </templates>
+        </handler>
         <!-- Keep the post and comment handlers seperate to ensure comments are structured below posts and not within the same folder structure as posts -->
         <handler type="Sitecore.Sharedsource.Tasks.NewsMover, Sitecore.Sharedsource.NewsMover" method="OnItemSaved" use="comments">
           <database>master</database>
@@ -66,11 +66,22 @@
         <processor type="Sitecore.Modules.WeBlog.Pipelines.TokenReplacer, Sitecore.Modules.WeBlog" />
       </expandInitialFieldValue>
       <weblogCreateComment>
+        <processor type="Sitecore.Modules.WeBlog.Pipelines.CreateComment.ProfanityFilter"/>
         <processor type="Sitecore.Modules.WeBlog.Pipelines.CreateComment.DuplicateSubmissionGuard"/>
         <processor type="Sitecore.Modules.WeBlog.Pipelines.CreateComment.CreateCommentItem"/>
         <!--<processor type="Sitecore.Modules.WeBlog.Pipelines.CreateComment.AkismetSpamCheck"/>-->
         <processor type="Sitecore.Modules.WeBlog.Pipelines.CreateComment.WorkflowSubmit"/>
       </weblogCreateComment>
+      <weblogProfanityFilter>
+        <processor type="Sitecore.Modules.WeBlog.Pipelines.ProfanityFilter.GetProfanityList"/>
+        <processor type="Sitecore.Modules.WeBlog.Pipelines.ProfanityFilter.ValidateInput">
+          <WholeWordsOnly>true</WholeWordsOnly>
+        </processor>
+        <!--<processor type="Sitecore.Modules.WeBlog.Pipelines.ProfanityFilter.FilterWords">
+          <Replacement>-_-</Replacement>
+          <WholeWordsOnly>true</WholeWordsOnly>
+        </processor>-->
+      </weblogProfanityFilter>
       <weblogGetSummary>
         <processor type="Sitecore.Modules.WeBlog.Pipelines.GetSummary.FromField">
           <!-- Optionally specify different field to pull the summary from. Defaults to 'Introduction' field -->
@@ -103,6 +114,8 @@
 
       <!-- The ID of the Workflow command to execute if the comment is classified as spam -->
       <setting name="WeBlog.Comments.Workflow.Command.Spam" value="{536C4CA1-B9EB-4CA8-9306-770478E1CCD6}"/>
+
+      <setting name="WeBlog.ProfanityFilterFile" value="$(dataFolder)/WeBlogProfanityFilter.txt"/>
 
       <!-- To use reCAPTCHA instead of the default captcha:
                 * In the Entry template's Standard Values, remove the SitecoreCaptcha sublayout

--- a/Website/Pipelines/CreateComment/ProfanityFilter.cs
+++ b/Website/Pipelines/CreateComment/ProfanityFilter.cs
@@ -1,0 +1,24 @@
+using Sitecore.Diagnostics;
+using Sitecore.Pipelines;
+
+namespace Sitecore.Modules.WeBlog.Pipelines.CreateComment
+{
+    public class ProfanityFilter : ICreateCommentProcessor
+    {
+        public void Process(CreateCommentArgs args)
+        {
+            Assert.IsNotNull(args.Comment, "Comment cannot be null");
+            ProfanityFilterArgs filterArgs = new ProfanityFilterArgs
+            {
+                Input = args.Comment.Text
+            };
+
+            CorePipeline.Run("weblogProfanityFilter", filterArgs);
+            if (!filterArgs.Valid)
+            {
+                args.AbortPipeline();
+            }
+            args.Comment.Text = filterArgs.Input;
+        }
+    }
+}

--- a/Website/Pipelines/IProfanityFilterProcessor.cs
+++ b/Website/Pipelines/IProfanityFilterProcessor.cs
@@ -1,0 +1,7 @@
+﻿namespace Sitecore.Modules.WeBlog.Pipelines
+{
+    public interface IProfanityFilterProcessor
+    {
+        void Process(ProfanityFilterArgs args);
+    }
+}

--- a/Website/Pipelines/ProfanityFilter/FilterWords.cs
+++ b/Website/Pipelines/ProfanityFilter/FilterWords.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace Sitecore.Modules.WeBlog.Pipelines.ProfanityFilter
+{
+    public class FilterWords : IProfanityFilterProcessor
+    {
+        public bool WholeWordsOnly { get; set; }
+        public string Replacement { get; set; }
+
+        public void Process(ProfanityFilterArgs args)
+        {
+            foreach (var p in args.WordList)
+            {
+                var indexOf = GetIndexOfProfanity(p, args.Input);
+                if (indexOf >= 0)
+                {
+                    var begin = args.Input.Substring(0, indexOf);
+                    var end = args.Input.Substring(indexOf + p.Length);
+                    args.Input = begin + Replacement + end;
+                }
+            }
+        }
+
+        private int GetIndexOfProfanity(string profanity, string text)
+        {
+            int indexOf = -1;
+            if (WholeWordsOnly)
+            {
+                var match = Regex.Match(text, String.Format(@"\b{0}\b", profanity), RegexOptions.IgnoreCase);
+                if (match.Success)
+                {
+                    indexOf = match.Index;
+                }
+            }
+            else
+            {
+                indexOf = text.IndexOf(profanity, StringComparison.OrdinalIgnoreCase);
+            }
+            return indexOf;
+        }
+    }
+}

--- a/Website/Pipelines/ProfanityFilter/GetProfanityList.cs
+++ b/Website/Pipelines/ProfanityFilter/GetProfanityList.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.IO;
+using Sitecore.IO;
+
+namespace Sitecore.Modules.WeBlog.Pipelines.ProfanityFilter
+{
+    public class GetProfanityList: IProfanityFilterProcessor
+    {
+        public void Process(ProfanityFilterArgs args)
+        {
+            args.WordList =  GetProfanityFileContent();
+        }
+
+        private IEnumerable<string> GetProfanityFileContent()
+        {
+            string filePath = Settings.ProfanityFilterFile;
+            if (FileUtil.Exists(filePath))
+            {
+                return File.ReadAllLines(filePath, System.Text.Encoding.Default);
+            }
+            return new string[0];
+        }
+    }
+}

--- a/Website/Pipelines/ProfanityFilter/ValidateInput.cs
+++ b/Website/Pipelines/ProfanityFilter/ValidateInput.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Sitecore.Modules.WeBlog.Pipelines.ProfanityFilter
+{
+    public class ValidateInput : IProfanityFilterProcessor
+    {
+        public bool WholeWordsOnly { get; set; }
+
+        public void Process(ProfanityFilterArgs args)
+        {
+            if (WholeWordsOnly)
+            {
+                args.Valid = !args.WordList
+                    .Select(GetPattern)
+                    .Any(p => Regex.Match(args.Input, p, RegexOptions.IgnoreCase).Success);
+            }
+            else
+            {
+                args.Valid = !args.WordList.Any(s => args.Input.IndexOf(s, StringComparison.OrdinalIgnoreCase) >= 0);
+            }
+        }
+
+        protected virtual string GetPattern(string word)
+        {
+            return String.Format(@"\b{0}\b", word);
+        }
+    }
+}

--- a/Website/Pipelines/ProfanityFilterArgs.cs
+++ b/Website/Pipelines/ProfanityFilterArgs.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using Sitecore.Pipelines;
+
+namespace Sitecore.Modules.WeBlog.Pipelines
+{
+    public class ProfanityFilterArgs : PipelineArgs
+    {
+        public string Input { get; set; }
+        public IEnumerable<string> WordList { get; set; }
+        public bool Valid { get; set; }
+
+        public ProfanityFilterArgs()
+        {
+            Valid = true;
+        }
+    }
+}

--- a/Website/Settings.cs
+++ b/Website/Settings.cs
@@ -13,7 +13,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string SearchIndexName
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.SearchIndexName", "WeBlog"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.SearchIndexName", "WeBlog"); }
         }
 
         /// <summary>
@@ -21,7 +21,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string EntryTemplateIDString
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.EntryTemplateID", "{5FA92FF4-4AC2-48E2-92EB-E1E4914677B0}"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.EntryTemplateID", "{5FA92FF4-4AC2-48E2-92EB-E1E4914677B0}"); }
         }
 
         /// <summary>
@@ -42,7 +42,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string CommentTemplateIDString
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.CommentTemplateID", "{70949D4E-35D8-4581-A7A2-52928AA119D5}"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.CommentTemplateID", "{70949D4E-35D8-4581-A7A2-52928AA119D5}"); }
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string BlogTemplateIDString
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.BlogTemplateID", "{46663E05-A6B8-422A-8E13-36CD2B041278}"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.BlogTemplateID", "{46663E05-A6B8-422A-8E13-36CD2B041278}"); }
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string CategoryTemplateIDString
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.CategoryTemplateID", "{61FF8D49-90D7-4E59-878D-DF6E03400D3B}"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.CategoryTemplateID", "{61FF8D49-90D7-4E59-878D-DF6E03400D3B}"); }
         }
 
         /// <summary>
@@ -105,7 +105,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string RssFeedTemplateIDString
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.RSSFeedTemplateID", "{B960CBE4-381F-4A2B-9F44-A43C7A991A0B}"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.RSSFeedTemplateID", "{B960CBE4-381F-4A2B-9F44-A43C7A991A0B}"); }
         }
 
         /// <summary>
@@ -126,7 +126,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string BlogBranchIDString
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.BlogBranchTemplateID", "{6FC4278C-E043-458B-9D5D-BBA775A9C386}"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.BlogBranchTemplateID", "{6FC4278C-E043-458B-9D5D-BBA775A9C386}"); }
         }
 
         /// <summary>
@@ -147,7 +147,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string ThemesRoot
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.ThemesRoot", "/sitecore/system/Modules/WeBlog/Themes"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.ThemesRoot", "/sitecore/system/Modules/WeBlog/Themes"); }
         }
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string GravatarImageServiceUrl
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.Gravatar.ImageService.Url", "http://www.gravatar.com/avatar"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.Gravatar.ImageService.Url", "http://www.gravatar.com/avatar"); }
         }
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string ReCaptchaPrivateKey
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.reCAPTCHA.PrivateKey"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.reCAPTCHA.PrivateKey"); }
         }
 
         /// <summary>
@@ -171,7 +171,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string ReCaptchaPublicKey
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.reCAPTCHA.PublicKey"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.reCAPTCHA.PublicKey"); }
         }
 
         /// <summary>
@@ -179,7 +179,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string AddThisAccountName
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.AddThisAccountName"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.AddThisAccountName"); }
         }
 
         /// <summary>
@@ -187,7 +187,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string ShareThisPublisherID
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.ShareThisPublisherID"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.ShareThisPublisherID"); }
         }
 
         /// <summary>
@@ -195,7 +195,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string AkismetAPIKey
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.Akismet.APIKey"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.Akismet.APIKey"); }
         }
 
         /// <summary>
@@ -203,7 +203,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string ContentRootPath
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.ContentRootPath", "/sitecore/content"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.ContentRootPath", "/sitecore/content"); }
         }
 
         /// <summary>
@@ -211,7 +211,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string GlobalizationCacheSize
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.Globalization.CacheSize"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.Globalization.CacheSize"); }
         }
 
         /// <summary>
@@ -219,7 +219,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string DictionaryPath
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.Globalization.DictonaryPath"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.Globalization.DictonaryPath"); }
         }
 
         /// <summary>
@@ -227,7 +227,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string DictionaryEntryTemplateIDString
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.Globalization.DictonaryEntryTemplateId"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.Globalization.DictonaryEntryTemplateId"); }
         }
 
         /// <summary>
@@ -248,7 +248,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static TimeSpan CaptchaMaximumTimeout
         {
-            get { return Sitecore.Configuration.Settings.GetTimeSpanSetting("WeBlog.Captcha.MaxTimeout", "00:01:00"); }
+            get { return Configuration.Settings.GetTimeSpanSetting("WeBlog.Captcha.MaxTimeout", "00:01:00"); }
         }
 
         /// <summary>
@@ -256,7 +256,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static TimeSpan CaptchaMinimumTimeout
         {
-            get { return Sitecore.Configuration.Settings.GetTimeSpanSetting("WeBlog.Captcha.MinTimeout", "00:00:03"); }
+            get { return Configuration.Settings.GetTimeSpanSetting("WeBlog.Captcha.MinTimeout", "00:00:03"); }
         }
 
         /// <summary>
@@ -264,7 +264,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string CommentWorkflowCommandCreated
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.Comments.Workflow.Command.Created",""); }
+            get { return Configuration.Settings.GetSetting("WeBlog.Comments.Workflow.Command.Created",""); }
         }
 
         /// <summary>
@@ -272,7 +272,15 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string CommentWorkflowCommandSpam
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.Comments.Workflow.Command.Spam"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.Comments.Workflow.Command.Spam"); }
+        }
+
+        /// <summary>
+        /// Gets the ProfanityFilter file path
+        /// </summary>
+        public static string ProfanityFilterFile
+        {
+            get { return Configuration.Settings.GetSetting("WeBlog.ProfanityFilterFile"); }
         }
 
         /// <summary>
@@ -280,7 +288,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string BlogManagerClass
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.Implementation.BlogManager"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.Implementation.BlogManager"); }
         }
 
         /// <summary>
@@ -288,7 +296,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string CategoryManagerClass
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.Implementation.CategoryManager"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.Implementation.CategoryManager"); }
         }
 
         /// <summary>
@@ -296,7 +304,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string CommentManagerClass
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.Implementation.CommentManager"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.Implementation.CommentManager"); }
         }
 
         /// <summary>
@@ -304,7 +312,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string EntryManagerClass
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.Implementation.EntryManager"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.Implementation.EntryManager"); }
         }
 
         /// <summary>
@@ -312,7 +320,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string TagManagerClass
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.Implementation.TagManager"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.Implementation.TagManager"); }
         }
 
         /// <summary>
@@ -320,7 +328,7 @@ namespace Sitecore.Modules.WeBlog
         /// </summary>
         public static string DateFormat
         {
-            get { return Sitecore.Configuration.Settings.GetSetting("WeBlog.DateFormat","MMMM dd yyyy"); }
+            get { return Configuration.Settings.GetSetting("WeBlog.DateFormat","MMMM dd yyyy"); }
         }
     }
 }

--- a/Website/Sitecore.Modules.WeBlog.csproj
+++ b/Website/Sitecore.Modules.WeBlog.csproj
@@ -197,6 +197,12 @@
     <Compile Include="Model\RecentCommentsRenderingModel.cs" />
     <Compile Include="Model\SubmitCommentRenderingModel.cs" />
     <Compile Include="Model\TagCloudRenderingModel.cs" />
+    <Compile Include="Pipelines\CreateComment\ProfanityFilter.cs" />
+    <Compile Include="Pipelines\IProfanityFilterProcessor.cs" />
+    <Compile Include="Pipelines\ProfanityFilterArgs.cs" />
+    <Compile Include="Pipelines\ProfanityFilter\FilterWords.cs" />
+    <Compile Include="Pipelines\ProfanityFilter\GetProfanityList.cs" />
+    <Compile Include="Pipelines\ProfanityFilter\ValidateInput.cs" />
     <Compile Include="Pipelines\RenderRendering\AppendVaryByBlogParameter.cs" />
     <Compile Include="Search\SearchTypes\CommentResultItem.cs" />
     <Compile Include="Search\SearchTypes\EntryResultItem.cs" />


### PR DESCRIPTION
With current code everything works like previously until you configure profanity filter.

To use profanity filter you should create text file under `("$(dataFolder)/WeBlogProfanityFilter.txt")` with inappropriate words inside (on per line).

Currently there are two modes:
* validate comments and abort pipeline if inappropriate word was detected (default)
* filter forbidden words before creating comments (to enable it you will have to use `FilterWords` processor instead of `ValidateInput`

WholeWordsOnly:
* true - only whole word will be detected
* false - any substring will be detected