### PR TITLE
#195 | Could not instantiate NVelocity during WP Import

### DIFF
--- a/src/Sitecore.Modules.WeBlog/Workflow/ExtendedMailAction.cs
+++ b/src/Sitecore.Modules.WeBlog/Workflow/ExtendedMailAction.cs
@@ -53,7 +53,14 @@ namespace Sitecore.Modules.WeBlog.Workflow
 
         public ExtendedMailAction()
         {
-            Velocity.Init();
+            try
+            {
+                Velocity.Init();
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex.Message, ex, this);
+            }
         }
 
         /// <summary>
@@ -61,6 +68,10 @@ namespace Sitecore.Modules.WeBlog.Workflow
         /// </summary>
         public virtual void Process(WorkflowPipelineArgs args)
         {
+            if (velocityContext==null)
+            {
+                return;
+            }
             CreateContext(args);
             Item item = args.ProcessorItem.InnerItem;
             string to = ProcessFieldValue("To", item);


### PR DESCRIPTION
This is not a complete fix for the issue, but `try` `catch` to prevent Import dialog from crash.

Problem occurs only during WP import. 
Normal workflow works fine. 