### PR TITLE
#197 | Do not render empty components

### DIFF
--- a/src/Sitecore.Modules.WeBlog.Mvc/Views/WeBlog/Archive.cshtml
+++ b/src/Sitecore.Modules.WeBlog.Mvc/Views/WeBlog/Archive.cshtml
@@ -2,32 +2,35 @@
 @using Sitecore.Modules.WeBlog.Globalization
 @model Sitecore.Modules.WeBlog.Mvc.Model.Archive
 
-<div class="wb-archive wb-panel" id="wb-archive">
-    <h3>@Translator.Render("ARCHIVE").ToHtmlString()</h3>
-    <ul>
-        @foreach (var year in Model.ArchiveCore.MonthsByYear)
-        {
-            <li class="wb-year-container">
-                <a class="wb-year @(Model.ExpandMonthsOnLoad ? "expanded" : "collapsed")" href="javascript:void(0)">@year.Key</a>
-                <ul id="month-@year.Key" class="wb-month @(Model.ExpandMonthsOnLoad ? "" : "collapsed")">
-                    @foreach (var month in year.Value)
-                    {
-                        var monthName = Model.ArchiveCore.GetFriendlyMonthName(month);
-                        var entries = Model.ArchiveCore.EntriesByMonthAndYear[month];
-                        <li>
-                            <a class="wb-month @(Model.ExpandPostsOnLoad ? "expanded" : "collapsed")" href="javascript:void(0)">@monthName (@entries.Count)</a>
-                            <ul id="entries-@monthName" class="wb-entries @(Model.ExpandPostsOnLoad ? "" : "collapsed")">
-                                @foreach (var entry in entries)
-                                {
-                                    <li>
-                                        <a href="@entry.Url">@entry.Title.Rendered.ToHtmlString()</a>
-                                    </li>
-                                }
-                            </ul>
-                        </li>
-                    }
-                </ul>
-            </li>
-        }
-    </ul>
-</div>
+@if (Model.ArchiveCore.EntriesByMonthAndYear.Any())
+{
+    <div class="wb-archive wb-panel" id="wb-archive">
+        <h3>@Translator.Render("ARCHIVE").ToHtmlString()</h3>
+        <ul>
+            @foreach (var year in Model.ArchiveCore.MonthsByYear)
+            {
+                <li class="wb-year-container">
+                    <a class="wb-year @(Model.ExpandMonthsOnLoad ? "expanded" : "collapsed")" href="javascript:void(0)">@year.Key</a>
+                    <ul id="month-@year.Key" class="wb-month @(Model.ExpandMonthsOnLoad ? "" : "collapsed")">
+                        @foreach (var month in year.Value)
+                        {
+                            var monthName = Model.ArchiveCore.GetFriendlyMonthName(month);
+                            var entries = Model.ArchiveCore.EntriesByMonthAndYear[month];
+                            <li>
+                                <a class="wb-month @(Model.ExpandPostsOnLoad ? "expanded" : "collapsed")" href="javascript:void(0)">@monthName (@entries.Count)</a>
+                                <ul id="entries-@monthName" class="wb-entries @(Model.ExpandPostsOnLoad ? "" : "collapsed")">
+                                    @foreach (var entry in entries)
+                                    {
+                                        <li>
+                                            <a href="@entry.Url">@entry.Title.Rendered.ToHtmlString()</a>
+                                        </li>
+                                    }
+                                </ul>
+                            </li>
+                        }
+                    </ul>
+                </li>
+            }
+        </ul>
+    </div>
+}

--- a/src/Sitecore.Modules.WeBlog.Mvc/Views/WeBlog/Categories.cshtml
+++ b/src/Sitecore.Modules.WeBlog.Mvc/Views/WeBlog/Categories.cshtml
@@ -2,14 +2,17 @@
 @using Sitecore.Modules.WeBlog.Globalization
 @model Sitecore.Modules.WeBlog.Mvc.Model.Categories
 
-<div class="wb-categories wb-panel">
-    <h3>@Translator.Render("CATEGORIES").ToHtmlString()</h3>
-    <ul>
-        @foreach (var categoryItem in Model.CategoryItems)
+@if (Model.CategoryItems.Any())
+{
+    <div class="wb-categories wb-panel">
+        <h3>@Translator.Render("CATEGORIES").ToHtmlString()</h3>
+        <ul>
+            @foreach (var categoryItem in Model.CategoryItems)
             {
-            <li>
-                <a href="@categoryItem.GetUrl()">@categoryItem.DisplayTitle.ToHtmlString()</a>
-            </li>
-        }
-    </ul>
-</div>
+                <li>
+                    <a href="@categoryItem.GetUrl()">@categoryItem.DisplayTitle.ToHtmlString()</a>
+                </li>
+            }
+        </ul>
+    </div>
+}

--- a/src/Sitecore.Modules.WeBlog.Mvc/Views/WeBlog/Feeds.cshtml
+++ b/src/Sitecore.Modules.WeBlog.Mvc/Views/WeBlog/Feeds.cshtml
@@ -2,15 +2,17 @@
 @using Sitecore.Modules.WeBlog.Globalization
 @model Sitecore.Modules.WeBlog.Mvc.Model.Feeds
 
-<div class="wb-feeds wb-panel">
-    <h3>@Translator.Render("SYNDICATION").ToHtmlString()</h3>
-    <ul>
-        @foreach (var feed in Model.FeedItems)
-        {
-            <li>
-                <a id="feedText" class="wb-feed-text" href="@feed.Url">@feed.Title.Text.ToHtmlString()</a>
-            </li>
-        }
-    </ul>
-</div>
-
+@if (Model.FeedItems.Any())
+{
+    <div class="wb-feeds wb-panel">
+        <h3>@Translator.Render("SYNDICATION").ToHtmlString()</h3>
+        <ul>
+            @foreach (var feed in Model.FeedItems)
+            {
+                <li>
+                    <a id="feedText" class="wb-feed-text" href="@feed.Url">@feed.Title.Text.ToHtmlString()</a>
+                </li>
+            }
+        </ul>
+    </div>
+}

--- a/src/Sitecore.Modules.WeBlog.Mvc/Views/WeBlog/InterestingEntries.cshtml
+++ b/src/Sitecore.Modules.WeBlog.Mvc/Views/WeBlog/InterestingEntries.cshtml
@@ -5,21 +5,24 @@
 @using Sitecore.Web
 @model Sitecore.Modules.WeBlog.Mvc.Model.InterestingEntries
 
-<div class="wb-interesting-entries wb-panel">
-    <h3>@Translator.Render("POPULAR_POSTS").ToHtmlString()</h3>
-    <ul>
-        @foreach (var entry in Model.Entries)
+@if (Model.Entries.Any())
+{
+    <div class="wb-interesting-entries wb-panel">
+        <h3>@Translator.Render("POPULAR_POSTS").ToHtmlString()</h3>
+        <ul>
+            @foreach (var entry in Model.Entries)
+            {
+                <li>
+                    <a href="@entry.Url">@entry.Title.Rendered.ToHtmlString()</a>
+                </li>
+            }
+        </ul>
+        @if (Model.Entries.Any() && Model.Algororithm != InterestingEntriesAlgorithm.Custom)
         {
-            <li>
-                <a href="@entry.Url">@entry.Title.Rendered.ToHtmlString()</a>
-            </li>
+            var homeUrl = WebUtil.RemoveQueryString(LinkManager.GetItemUrl(Model.CurrentBlog.InnerItem));
+            <a class="wb-view-more" href="@homeUrl?sort=@Model.Mode.ToLower()">
+                @Translator.Render("VIEW_MORE").ToHtmlString()
+            </a>
         }
-    </ul>
-    @if (Model.Entries.Any() && Model.Algororithm != InterestingEntriesAlgorithm.Custom)
-    {
-        var homeUrl = WebUtil.RemoveQueryString(LinkManager.GetItemUrl(Model.CurrentBlog.InnerItem));
-        <a class="wb-view-more" href="@homeUrl?sort=@Model.Mode.ToLower()">
-            @Translator.Render("VIEW_MORE").ToHtmlString()
-        </a>
-    }
-</div>
+    </div>
+}

--- a/src/Sitecore.Modules.WeBlog.WebForms/Layouts/WeBlog/PostList.ascx
+++ b/src/Sitecore.Modules.WeBlog.WebForms/Layouts/WeBlog/PostList.ascx
@@ -13,8 +13,8 @@
             <%#Translator.Render("NO_POSTS_FOUND")%>
         </EmptyDataTemplate>
     </asp:ListView>
-    <div class="wb-view-more-wrapper">
+    <asp:Panel ID="PanelViewMore" runat="server" CssClass="wb-view-more-wrapper">
         <a runat="server" id="ancViewMore" class="wb-view-more" href="#"><%=Translator.Render("VIEW_MORE")%></a>
         <span class="wb-loading-animation" style="display: none;">Loading...</span>
-    </div>
+    </asp:Panel>
 </div>

--- a/src/Sitecore.Modules.WeBlog.WebForms/Layouts/WeBlog/PostList.ascx.cs
+++ b/src/Sitecore.Modules.WeBlog.WebForms/Layouts/WeBlog/PostList.ascx.cs
@@ -39,9 +39,9 @@ namespace Sitecore.Modules.WeBlog.WebForms.Layouts
                 EntryList.DataBind();
             }
 
-            if (ancViewMore != null)
+            if (PanelViewMore != null)
             {
-                ancViewMore.Visible = PostListCore.ShowViewMoreLink;
+                PanelViewMore.Visible = PostListCore.ShowViewMoreLink;
                 if (PostListCore.ShowViewMoreLink)
                 {
                     ancViewMore.HRef = PostListCore.ViewMoreHref;

--- a/src/Sitecore.Modules.WeBlog.WebForms/Layouts/WeBlog/PostList.ascx.designer.cs
+++ b/src/Sitecore.Modules.WeBlog.WebForms/Layouts/WeBlog/PostList.ascx.designer.cs
@@ -22,6 +22,15 @@ namespace Sitecore.Modules.WeBlog.WebForms.Layouts {
         protected global::System.Web.UI.WebControls.ListView EntryList;
         
         /// <summary>
+        /// PanelViewMore control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Panel PanelViewMore;
+        
+        /// <summary>
         /// ancViewMore control.
         /// </summary>
         /// <remarks>

--- a/src/Sitecore.Modules.WeBlog.WebForms/Layouts/WeBlog/Sidebar/Archive.ascx
+++ b/src/Sitecore.Modules.WeBlog.WebForms/Layouts/WeBlog/Sidebar/Archive.ascx
@@ -1,6 +1,6 @@
 ﻿<%@ Control Language="C#" AutoEventWireup="true" CodeBehind="Archive.ascx.cs" Inherits="Sitecore.Modules.WeBlog.WebForms.Layouts.Sidebar.BlogArchive" %>
 
-<div class="wb-archive wb-panel" id="wb-archive">
+<asp:Panel ID="PanelArchive" runat="server" CssClass="wb-archive wb-panel">
     <h3><%=Sitecore.Modules.WeBlog.Globalization.Translator.Render("ARCHIVE")%></h3>
     <asp:Repeater runat="server" ID="Years" ItemType="System.Int32">
         <HeaderTemplate>
@@ -41,4 +41,4 @@
             </ul>
         </FooterTemplate>
     </asp:Repeater>
-</div>
+</asp:Panel>

--- a/src/Sitecore.Modules.WeBlog.WebForms/Layouts/WeBlog/Sidebar/Archive.ascx.cs
+++ b/src/Sitecore.Modules.WeBlog.WebForms/Layouts/WeBlog/Sidebar/Archive.ascx.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Web.UI.WebControls;
 using Sitecore.Modules.WeBlog.Components;
 using Sitecore.Modules.WeBlog.Converters;
@@ -39,9 +40,17 @@ namespace Sitecore.Modules.WeBlog.WebForms.Layouts.Sidebar
 
         protected virtual void Page_Load(object sender, EventArgs e)
         {
-            ExpandMonthsOnLoad = true;
-            Years.DataSource = ArchiveCore.MonthsByYear.Keys;
-            Years.DataBind();
+            var monthsByYearKeys = ArchiveCore.MonthsByYear.Keys;
+            if (monthsByYearKeys.Any())
+            {                
+                Years.DataSource = monthsByYearKeys;
+                Years.DataBind();
+                PanelArchive.Visible = true;
+            }
+            else
+            {
+                PanelArchive.Visible = false;
+            }
         }
 
         protected virtual int[] GetMonths(int year)

--- a/src/Sitecore.Modules.WeBlog.WebForms/Layouts/WeBlog/Sidebar/Archive.ascx.designer.cs
+++ b/src/Sitecore.Modules.WeBlog.WebForms/Layouts/WeBlog/Sidebar/Archive.ascx.designer.cs
@@ -13,6 +13,15 @@ namespace Sitecore.Modules.WeBlog.WebForms.Layouts.Sidebar {
     public partial class BlogArchive {
         
         /// <summary>
+        /// PanelArchive control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Panel PanelArchive;
+        
+        /// <summary>
         /// Years control.
         /// </summary>
         /// <remarks>

--- a/src/Sitecore.Modules.WeBlog.WebForms/Layouts/WeBlog/Sidebar/InterestingEntries.ascx
+++ b/src/Sitecore.Modules.WeBlog.WebForms/Layouts/WeBlog/Sidebar/InterestingEntries.ascx
@@ -1,6 +1,6 @@
 ﻿<%@ Control Language="C#" AutoEventWireup="true" CodeBehind="InterestingEntries.ascx.cs" Inherits="Sitecore.Modules.WeBlog.WebForms.Layouts.Sidebar.BlogInterestingEntries" %>
 
-<div class="wb-interesting-entries wb-panel">
+<asp:Panel ID="PanelInteresingEntries" runat="server" CssClass="wb-interesting-entries wb-panel">
     <h3><%= Sitecore.Modules.WeBlog.Globalization.Translator.Render("POPULAR_POSTS") %></h3>
     <asp:Repeater runat="server" ID="ItemList" ItemType="Sitecore.Modules.WeBlog.Data.Items.EntryItem">
         <HeaderTemplate>
@@ -15,4 +15,4 @@
             </ul>
         </FooterTemplate>
     </asp:Repeater>
-</div>
+</asp:Panel>

--- a/src/Sitecore.Modules.WeBlog.WebForms/Layouts/WeBlog/Sidebar/InterestingEntries.ascx.cs
+++ b/src/Sitecore.Modules.WeBlog.WebForms/Layouts/WeBlog/Sidebar/InterestingEntries.ascx.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Sitecore.Modules.WeBlog.Components;
 using Sitecore.Modules.WeBlog.Managers;
 using Sitecore.Modules.WeBlog.Search;
@@ -28,7 +29,7 @@ namespace Sitecore.Modules.WeBlog.WebForms.Layouts.Sidebar
         {
             base.OnInit(e);
 
-            var algororithm = Modules.WeBlog.Components.InterestingEntriesCore.GetAlgororithmFromString(Mode);
+            var algororithm = WeBlog.Components.InterestingEntriesCore.GetAlgororithmFromString(Mode);
             if (algororithm != InterestingEntriesAlgorithm.Custom || InterestingEntriesCore == null)
             {
                 InterestingEntriesCore = new InterestingEntriesCore(ManagerFactory.EntryManagerInstance, algororithm);
@@ -37,13 +38,17 @@ namespace Sitecore.Modules.WeBlog.WebForms.Layouts.Sidebar
 
         protected void Page_Load(object sender, EventArgs e)
         {
-            PopulateList();
-        }
-
-        protected virtual void PopulateList()
-        {
-            ItemList.DataSource = InterestingEntriesCore.GetEntries(CurrentBlog, MaximumCount);
-            ItemList.DataBind();
+            var dataSource = InterestingEntriesCore.GetEntries(CurrentBlog, MaximumCount);
+            if (dataSource.Any())
+            {
+                ItemList.DataSource = dataSource;
+                ItemList.DataBind();
+                PanelInteresingEntries.Visible = true;
+            }
+            else
+            {
+                PanelInteresingEntries.Visible = false;
+            }
         }
     }
 }

--- a/src/Sitecore.Modules.WeBlog.WebForms/Layouts/WeBlog/Sidebar/InterestingEntries.ascx.designer.cs
+++ b/src/Sitecore.Modules.WeBlog.WebForms/Layouts/WeBlog/Sidebar/InterestingEntries.ascx.designer.cs
@@ -13,6 +13,15 @@ namespace Sitecore.Modules.WeBlog.WebForms.Layouts.Sidebar {
     public partial class BlogInterestingEntries {
         
         /// <summary>
+        /// PanelInteresingEntries control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Panel PanelInteresingEntries;
+        
+        /// <summary>
         /// ItemList control.
         /// </summary>
         /// <remarks>

--- a/src/Sitecore.Modules.WeBlog/Data/Items/BlogHomeItem.cs
+++ b/src/Sitecore.Modules.WeBlog/Data/Items/BlogHomeItem.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using Sitecore.Data.Items;
 using Sitecore.Data.Managers;
 using Sitecore.Links;
@@ -289,19 +290,15 @@ namespace Sitecore.Modules.WeBlog.Data.Items
         {
             get
             {
-                List<RssFeedItem> feeds = null;
+                List<RssFeedItem> feeds = new List<RssFeedItem>();
                 if (this.EnableRss.Checked)
-                {
+                {                    
                     var rssTemplateId = Settings.RssFeedTemplateIDString;
-                    var feedItems = this.InnerItem.Axes.SelectItems(string.Format("./*[@@templateid='{0}']", rssTemplateId));
+                    var feedItems = this.InnerItem.Axes.SelectItems($"./*[@@templateid='{rssTemplateId}']");
                      
                     if (feedItems != null)
                     {
-                        feeds = new List<RssFeedItem>();
-                        foreach (Item item in feedItems)
-                        {
-                            feeds.Add(new RssFeedItem(item));
-                        }
+                        feeds.AddRange(feedItems.Select(item => new RssFeedItem(item)));
                     }
                 }
                 return feeds;


### PR DESCRIPTION
Fixed: Do not render components at all if there is nothing to display
Fixed: Null refference exception when there are no feed items under blog root item