### PR TITLE
#202 | Interesting Entries throws an error when analytics are disabled

### DIFF
--- a/Test/IntegrationTest/Managers/EntryManagerFixture.cs
+++ b/Test/IntegrationTest/Managers/EntryManagerFixture.cs
@@ -213,7 +213,7 @@ namespace Sitecore.Modules.WeBlog.IntegrationTest.Managers
             TestUtil.UpdateIndex();
 
             var manager = new EntryManager();
-            var results = manager.GetBlogEntries(blog, 10, "blurr", null, null, null);            
+            var results = manager.GetBlogEntries(blog, 10, "blurr", null, null, null);
 
             Assert.That(results, Is.Empty);
         }
@@ -224,7 +224,7 @@ namespace Sitecore.Modules.WeBlog.IntegrationTest.Managers
             var blog = TestUtil.CreateNewBlog(TestContentRoot);
             var categoryAlpha = TestUtil.CreateNewCategory(blog, "Alpha");
             var categoryBeta = TestUtil.CreateNewCategory(blog, "Beta");
-            var entryLuna = TestUtil.CreateNewEntry(blog, "Luna", categories: new [] { categoryBeta.ID }, entryDate: new DateTime(2012, 3, 1));
+            var entryLuna = TestUtil.CreateNewEntry(blog, "Luna", categories: new[] { categoryBeta.ID }, entryDate: new DateTime(2012, 3, 1));
             var entryDeimos = TestUtil.CreateNewEntry(blog, "Deimos", categories: new[] { categoryAlpha.ID, categoryBeta.ID }, entryDate: new DateTime(2012, 3, 2));
             var entryPhobos = TestUtil.CreateNewEntry(blog, "Phobos", categories: new[] { categoryBeta.ID, categoryAlpha.ID }, entryDate: new DateTime(2012, 3, 3));
             var entryAdrastea = TestUtil.CreateNewEntry(blog, "Adrastea", categories: new[] { categoryBeta.ID, categoryAlpha.ID }, entryDate: new DateTime(2012, 3, 4));
@@ -540,7 +540,7 @@ namespace Sitecore.Modules.WeBlog.IntegrationTest.Managers
             var entries = manager.GetPopularEntriesByView(blog, 1);
             var entryIds = from entry in entries select entry.ID;
 
-            Assert.That(entryIds, Is.EqualTo(new[] { entryLuna.ID } ));
+            Assert.That(entryIds, Is.EqualTo(new[] { entryLuna.ID }));
         }
 
         [Test]
@@ -569,7 +569,10 @@ namespace Sitecore.Modules.WeBlog.IntegrationTest.Managers
 
         private void VerifyAnalyticsSetup()
         {
-            Assert.True(Sitecore.Configuration.Settings.Analytics.Enabled, "Sitecore.Analytics must be enabled to test");
+            bool enabled = Sitecore.Configuration.Settings.GetBoolSetting("Analytics.Enabled", false)
+                || Sitecore.Configuration.Settings.GetBoolSetting("Xdb.Enabled", false);
+
+            Assert.True(enabled, "Sitecore.Analytics must be enabled to test");
         }
 
         private EntryManager CreateEntryManagerForAnalyticsTest(params ID[] popularEntryIdsInOrder)
@@ -612,7 +615,7 @@ namespace Sitecore.Modules.WeBlog.IntegrationTest.Managers
                 {
                     new DataColumn("Visits", typeof(long))
                 });
-            
+
                 dataTable.Rows.Add(visitCount);
                 visitCount--;
 

--- a/src/Sitecore.Modules.WeBlog/Managers/EntryManager.cs
+++ b/src/Sitecore.Modules.WeBlog/Managers/EntryManager.cs
@@ -12,6 +12,7 @@ using Sitecore.ContentSearch;
 using Sitecore.ContentSearch.Linq.Utilities;
 using Sitecore.ContentSearch.Security;
 using Sitecore.Modules.WeBlog.Configuration;
+using Sitecore.Modules.WeBlog.Diagnostics;
 using Sitecore.Modules.WeBlog.Search.SearchTypes;
 #if FEATURE_XDB
 using Sitecore.Modules.WeBlog.Analytics.Reporting;
@@ -153,15 +154,15 @@ namespace Sitecore.Modules.WeBlog.Managers
             }
 
             var customBlogItem = (from templateId in Settings.BlogTemplateIds
-                where blog.TemplateIsOrBasedOn(templateId)
-                select (BlogHomeItem)blog).FirstOrDefault();
+                                  where blog.TemplateIsOrBasedOn(templateId)
+                                  select (BlogHomeItem)blog).FirstOrDefault();
 
             if (customBlogItem == null)
             {
                 customBlogItem = (from templateId in Settings.BlogTemplateIds
-                                 let item = blog.FindAncestorByTemplate(templateId)
-                                 where item != null
-                                 select (BlogHomeItem)item).FirstOrDefault();
+                                  let item = blog.FindAncestorByTemplate(templateId)
+                                  where item != null
+                                  select (BlogHomeItem)item).FirstOrDefault();
             }
 
             if (customBlogItem == null)
@@ -290,6 +291,10 @@ namespace Sitecore.Modules.WeBlog.Managers
                     return (from id in ids select blogEntries.First(i => i.ID == id)).ToArray();
                 }
             }
+            else
+            {
+                Logger.Warn("Sitecore.Analytics must be enabled to get popular entries by view.", this);
+            }
             return new EntryItem[0];
         }
 
@@ -342,7 +347,7 @@ namespace Sitecore.Modules.WeBlog.Managers
             var current = new EntryItem(Context.Item);
             return current;
         }
-        
+
         /// <summary>
         /// Gets the current context item as a blog entry
         /// </summary>
@@ -352,9 +357,9 @@ namespace Sitecore.Modules.WeBlog.Managers
         public virtual EntryItem GetCurrentBlogEntry(Item item)
         {
             return (from templateId in Settings.EntryTemplateIds
-                let entryItem = item.FindAncestorByTemplate(templateId)
-                where entryItem != null
-                select new EntryItem(entryItem)).FirstOrDefault();
+                    let entryItem = item.FindAncestorByTemplate(templateId)
+                    where entryItem != null
+                    select new EntryItem(entryItem)).FirstOrDefault();
         }
 
         /// <summary>
@@ -533,9 +538,9 @@ namespace Sitecore.Modules.WeBlog.Managers
         public virtual EntryItem[] MakeSortedEntriesList(IList array)
         {
             var entryList = (from Item item in array
-                where item.TemplateIsOrBasedOn(Settings.EntryTemplateIds)
-                && item.Versions.Count > 0
-                select new EntryItem(item)).ToList();
+                             where item.TemplateIsOrBasedOn(Settings.EntryTemplateIds)
+                             && item.Versions.Count > 0
+                             select new EntryItem(item)).ToList();
 
             entryList.Sort(new PostDateComparerDesc());
 

--- a/test/UnitTest/Managers/EntryManagerFixture.cs
+++ b/test/UnitTest/Managers/EntryManagerFixture.cs
@@ -1,10 +1,16 @@
-﻿using System.Linq;
+﻿using System.Data;
+using System.Linq;
 using Moq;
 using NUnit.Framework;
+using Sitecore.Analytics.Reporting;
+using Sitecore.ContentSearch;
+using Sitecore.ContentSearch.Security;
 using Sitecore.Data;
 using Sitecore.FakeDb;
 using Sitecore.Modules.WeBlog.Configuration;
+using Sitecore.Modules.WeBlog.Data.Items;
 using Sitecore.Modules.WeBlog.Managers;
+using Sitecore.Modules.WeBlog.Search.SearchTypes;
 
 namespace Sitecore.Modules.WeBlog.UnitTest
 {
@@ -262,13 +268,84 @@ namespace Sitecore.Modules.WeBlog.UnitTest
             }
         }
 
+        [Test]
+        [TestCase("Analytics.Enabled", "false", 0, TestName = "Analytics disabled")]
+        [TestCase("Analytics.Enabled", "true", 1, TestName = "Analytics enabled")]
+        [TestCase("Xdb.Enabled", "false", 0, TestName = "Xdb disabled")]
+        [TestCase("Xdb.Enabled", "true", 1)]
+        public void GetPopularEntriesByView(string settingName, string settingValue, int expected)
+        {
+            var settings = MockSettings(ID.NewID);
+            var dataProvider = MockDataProvider();
+            var manager = new EntryManager(dataProvider.Object, settings);
+
+            using (var db = new Db
+            {
+                new DbItem("blog", ID.NewID, settings.BlogTemplateIds.First()) {
+                    new DbItem("2013", ID.NewID, ID.NewID)
+                    {
+                        new DbItem("entry1", ID.NewID, settings.EntryTemplateIds.First()),
+                    }
+                }
+            })
+            {
+                try
+                {
+                    // Assign
+                    var blogItem = db.GetItem("/sitecore/content/blog");
+                    var entry1 = db.GetItem("/sitecore/content/blog/2013/entry1");
+                    var index = new Mock<ISearchIndex>();
+                    ContentSearchManager.SearchConfiguration.Indexes.Add("WeBlog", index.Object);
+
+                    var srItem = new Mock<EntryResultItem>();
+                    srItem.Setup(x => x.GetItem()).Returns(entry1);
+                    srItem.Setup(x => x.TemplateId).Returns((new BlogHomeItem(blogItem)).BlogSettings.EntryTemplateID);
+                    srItem.Setup(x => x.Paths).Returns(new[] { blogItem.ID });
+                    srItem.Setup(x => x.Language).Returns(blogItem.Language.ToString);
+                    srItem.Setup(x => x.DatabaseName).Returns(blogItem.Database.Name);
+
+                    index.Setup(i => i.CreateSearchContext(It.IsAny<SearchSecurityOptions>()).GetQueryable<EntryResultItem>())
+                        .Returns(new EnumerableQuery<EntryResultItem>(new[] { srItem.Object }));
+
+                    db.Configuration.Settings[settingName] = settingValue;
+
+                    // Act
+                    var entryItems = manager.GetPopularEntriesByView(blogItem, 10);
+
+                    // Assert
+                    Assert.That(entryItems.Length, Is.EqualTo(expected));
+
+                }
+                finally
+                {
+                    ContentSearchManager.SearchConfiguration.Indexes.Remove("WeBlog");
+                }
+
+            }
+        }
+
+        private Mock<ReportDataProviderBase> MockDataProvider()
+        {
+            var dataProvider = new Mock<ReportDataProviderBase>();
+            DataTable dt = new DataTable();
+            dt.Clear();
+            dt.Columns.Add("Visits", typeof(long));
+            DataRow row = dt.NewRow();
+            row["Visits"] = 1;
+            dt.Rows.Add(row);
+            dataProvider.Setup(b => b.GetData(It.IsAny<string>(), It.IsAny<ReportDataQuery>(), It.IsAny<CachingPolicy>()))
+                .Returns(new ReportDataResponse(() => dt));
+            return dataProvider;
+        }
+
         private IWeBlogSettings MockSettings(params ID[] entryTemplateIds)
-        {            
+        {
             return Mock.Of<IWeBlogSettings>(x =>
                 x.BlogTemplateIds == new[] { ID.NewID, ID.NewID } &&
                 x.CategoryTemplateIds == new[] { ID.NewID, ID.NewID } &&
                 x.EntryTemplateIds == entryTemplateIds &&
-                x.CommentTemplateIds == new[] { ID.NewID }
+                x.CommentTemplateIds == new[] { ID.NewID } &&
+                x.SearchIndexName == "WeBlog"
             );
         }
     }

--- a/test/UnitTest/UnitTest.csproj
+++ b/test/UnitTest/UnitTest.csproj
@@ -69,6 +69,10 @@
     <Reference Include="Sitecore.ContentSearch">
       <HintPath>$(SitecorePath)\bin\Sitecore.ContentSearch.dll</HintPath>
     </Reference>
+    <Reference Include="Sitecore.ContentSearch.Linq, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>$(SitecorePath)\bin\Sitecore.ContentSearch.Linq.dll</HintPath>
+    </Reference>
     <Reference Include="Sitecore.FakeDb, Version=1.1.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Sitecore.FakeDb.1.1.1\lib\net45\Sitecore.FakeDb.dll</HintPath>
       <Private>True</Private>


### PR DESCRIPTION
I created method `AnalyticsEnabled` intentionally, otherwise we would need to create another version configuration for our solution. 
If needed let's do this in separate task. I wanted to keep this as it is to be able to create single package for Sitecore 8.0+
Since Sitecore 8.1 setting: `Analytics.Enabled` is no longer used (new setting name: `Xdb.Enabled`)

I managed to create Unit Test for that with Content Search mock. 
I believe this will let us test more things with unit test.

EDIT:
It seems that we need to split it, as in Sitecore 8.2 this setting is no longer present.
https://github.com/WeTeam/WeBlog/blob/develop/Test/IntegrationTest/Managers/EntryManagerFixture.cs#L572
