### PR TITLE
#212 | Index in not updated after new item is added

### DIFF
--- a/src/Sitecore.Modules.WeBlog/App_Config/Include/WeBlog.config
+++ b/src/Sitecore.Modules.WeBlog/App_Config/Include/WeBlog.config
@@ -11,6 +11,9 @@
       </services>
     </api>
     <events>
+      <event name="item:added">
+        <handler type="Sitecore.Modules.WeBlog.EventHandlers.RebuildIndexTree, Sitecore.Modules.WeBlog" method="OnItemAdded" />
+      </event>      
       <event name="item:saved">
         <handler type="Sitecore.Modules.WeBlog.EventHandlers.SyncBucket, Sitecore.Modules.WeBlog" method="OnItemSaved" />
         <handler type="Sitecore.Modules.WeBlog.Globalization.ItemAndPublishEventHandler, Sitecore.Modules.WeBlog" method="OnItemSaved"/>

--- a/src/Sitecore.Modules.WeBlog/EventHandlers/RebuildIndexTree.cs
+++ b/src/Sitecore.Modules.WeBlog/EventHandlers/RebuildIndexTree.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Linq;
+using Sitecore.Buckets.Managers;
+using Sitecore.ContentSearch;
+using Sitecore.ContentSearch.Maintenance;
+using Sitecore.Data.Items;
+using Sitecore.Diagnostics;
+using Sitecore.Events;
+using Sitecore.Jobs.AsyncUI;
+
+namespace Sitecore.Modules.WeBlog.EventHandlers
+{
+    public class RebuildIndexTree
+    {
+        public void OnItemAdded(object sender, EventArgs args)
+        {
+            Assert.ArgumentNotNull(sender, "sender");
+            Assert.ArgumentNotNull(args, "args");
+
+            Item item = Event.ExtractParameter(args, 0) as Item;
+            if (item == null || !BucketManager.IsBucketable(item) || IsPublish())
+            {
+                return;
+            }
+
+            Item bucketRoot = GetBucketRoot(item);
+            if (bucketRoot != null && BucketManager.IsBucket(bucketRoot))
+            {
+                // do not remove ToArray() call
+                IndexCustodian.RefreshTree((SitecoreIndexableItem)item).ToArray();
+            }
+        }
+
+        private bool IsPublish()
+        {
+            return JobContext.IsJob && JobContext.Job.Category == "publish";
+        }
+
+        protected virtual Item GetBucketRoot(Item item)
+        {
+            var current = item;
+            do
+            {
+                current = current.Parent;
+            }
+            while (current?.Parent != null && !BucketManager.IsBucket(current));
+
+            return current;
+        }
+    }
+}

--- a/src/Sitecore.Modules.WeBlog/Sitecore.Modules.WeBlog.csproj
+++ b/src/Sitecore.Modules.WeBlog/Sitecore.Modules.WeBlog.csproj
@@ -163,6 +163,7 @@
     <Compile Include="Caching\TranslatorCache.cs" />
     <Compile Include="Caching\CacheManager.cs" />
     <Compile Include="Caching\SimpleCache.cs" />
+    <Compile Include="EventHandlers\RebuildIndexTree.cs" />
     <Compile Include="Templates.cs" />
     <Compile Include="Configuration\IWeBlogSettings.cs" />
     <Compile Include="Configuration\WeBlogSettings.cs" />


### PR DESCRIPTION
Fix for #212 

Very strange behaviour. It seems that this issue is actually caused by some Sitecore issue/change.

Starting from the latest update (8.1 - **160302**) different behaviour with multiple index crawler can be observed.

Right now, if you have multiple crawlers defined, only first is fired, second seems not work. 
```xml
<locations hint="list:AddCrawler">
    <crawler type="Sitecore.ContentSearch.SitecoreItemCrawler, Sitecore.ContentSearch">
        <Database>web</Database>
        <Root>/sitecore/content</Root>
    </crawler>
    <crawler type="Sitecore.ContentSearch.SitecoreItemCrawler, Sitecore.ContentSearch">
        <Database>master</Database>
        <Root>/sitecore/content</Root>
    </crawler>
</locations>
```


So if you create a new item in the **master** database you won't see anything when you open blog in preview.
But if you publish items and open it in normal mode you will see results from **web**.

If you change the order of the crawlers behaviour will be opposite to the previous one (items indexed for **master**, not for **web**)


As a workaround I implemented this additional processor which trigger item re-index once it is added the the bucket.