### PR TITLE
#290 Use explicit content database, rather than context database for …

### DIFF
--- a/Test/UnitTest/Caching/ProfanityFilterCacheFixture.cs
+++ b/Test/UnitTest/Caching/ProfanityFilterCacheFixture.cs
@@ -1,0 +1,91 @@
+﻿using Moq;
+using NUnit.Framework;
+using Sitecore.Caching;
+using Sitecore.Data;
+using Sitecore.Modules.WeBlog.Caching;
+
+namespace Sitecore.Modules.WeBlog.UnitTest.Caching
+{
+    [TestFixture]
+    public class ProfanityFilterCacheFixture
+    {
+        [Test]
+        public void WordListGet_DatabaseIsNullAndNothingSet_ReturnsNull()
+        {
+            // arrange
+            var innerCache = Mock.Of<ICache>();
+            var sut = new ProfanityFilterCache(innerCache, null);
+
+            // act
+            var words = sut.WordList;
+
+            // assert
+            Assert.That(words, Is.Null);
+        }
+
+        [Test]
+        public void WordListGet_NothingSet_ReturnsNull()
+        {
+            // arrange
+            var innerCache = Mock.Of<ICache>();
+            var database = Mock.Of<Database>(x => x.Name == "database");
+            var sut = new ProfanityFilterCache(innerCache, database);
+
+            // act
+            var words = sut.WordList;
+
+            // assert
+            Assert.That(words, Is.Null);
+        }
+
+        [Test]
+        public void WordListGet_InnerCacheHasEntries_ReturnsWords()
+        {
+            // arrange
+#pragma warning disable CS0252 // Possible unintended reference comparison; left hand side needs cast
+            var innerCache = Mock.Of<ICache>(x => x.GetValue("wordlist_database") == "lorem|ipsum");
+#pragma warning restore CS0252 // Possible unintended reference comparison; left hand side needs cast
+            var database = Mock.Of<Database>(x => x.Name == "database");
+            var sut = new ProfanityFilterCache(innerCache, database);
+
+            // act
+            var words = sut.WordList;
+
+            // assert
+            Assert.That(words, Is.EquivalentTo(new[] { "lorem", "ipsum" }));
+        }
+
+        [Test]
+        public void WordListSet_WordsSet_SavesWordsToInnerCache()
+        {
+            // arrange
+            var innerCache = new Mock<ICache>();
+            innerCache.Setup(x => x.Enabled).Returns(true);
+
+            var database = Mock.Of<Database>(x => x.Name == "database");
+            var sut = new ProfanityFilterCache(innerCache.Object, database);
+
+            // act
+            sut.WordList = new[] { "lorem", "ipsum" };
+
+            // assert
+            innerCache.Verify(x => x.Add("wordlist_database", "lorem|ipsum"));
+        }
+
+        [Test]
+        public void WordListSet_DatabaseIsNullAndWordsSet_SavesWordsToInnerCache()
+        {
+            // arrange
+            var innerCache = new Mock<ICache>();
+            innerCache.Setup(x => x.Enabled).Returns(true);
+
+            var sut = new ProfanityFilterCache(innerCache.Object, null);
+
+            // act
+            sut.WordList = new[] { "lorem", "ipsum" };
+
+            // assert
+            innerCache.Verify(x => x.Add("wordlist_nodb", "lorem|ipsum"));
+        }
+    }
+}

--- a/Test/UnitTest/Data/Items/ScribanMailActionItemFixture.cs
+++ b/Test/UnitTest/Data/Items/ScribanMailActionItemFixture.cs
@@ -83,7 +83,7 @@ namespace Sitecore.Modules.WeBlog.UnitTest.Data.Items
         {
             // arrange
             var itemMock = ItemFactory.CreateItem();
-            ItemFactory.SetField(itemMock, fieldName, fieldValue);
+            ItemFactory.SetIndexerField(itemMock, fieldName, fieldValue);
 
             var item = itemMock.Object;
             var sut = new ScribanMailActionItem(item);

--- a/Test/UnitTest/ItemFactory.cs
+++ b/Test/UnitTest/ItemFactory.cs
@@ -1,6 +1,9 @@
 ﻿using Moq;
+using Sitecore.Collections;
 using Sitecore.Data;
+using Sitecore.Data.Fields;
 using Sitecore.Data.Items;
+using System.Collections.Generic;
 
 namespace Sitecore.Modules.WeBlog.UnitTest
 {
@@ -25,14 +28,27 @@ namespace Sitecore.Modules.WeBlog.UnitTest
             return itemMock;
         }
 
-        public static void SetField(Mock<Item> itemMock, string fieldName, string fieldValue)
+        public static void SetIndexerField(Mock<Item> itemMock, string fieldName, string fieldValue)
         {
             itemMock.Setup(x => x[fieldName]).Returns(fieldValue);
         }
 
-        public static void SetField(Mock<Item> itemMock, ID fieldId, string fieldValue)
+        public static void SetIndexerField(Mock<Item> itemMock, ID fieldId, string fieldValue)
         {
             itemMock.Setup(x => x[fieldId]).Returns(fieldValue);
+        }
+
+        public static void AddFields(Mock<Item> itemMock, IEnumerable<Field> fields)
+        {
+            var fieldCollectionMock = new Mock<FieldCollection>(itemMock.Object);
+
+            foreach (var field in fields)
+            {
+                fieldCollectionMock.Setup(x => x[field.ID]).Returns(field);
+                fieldCollectionMock.Setup(x => x[field.Name]).Returns(field);
+            }
+
+            itemMock.Setup(x => x.Fields).Returns(fieldCollectionMock.Object);
         }
     }
 }

--- a/Test/UnitTest/Pipelines/PopulateScribanMailActionModel/AddNextWorkflowStateFixture.cs
+++ b/Test/UnitTest/Pipelines/PopulateScribanMailActionModel/AddNextWorkflowStateFixture.cs
@@ -61,7 +61,7 @@ namespace Sitecore.Modules.WeBlog.UnitTest.Pipelines.PopulateScribanMailActionMo
             database.Setup(x => x.GetItem(nextStateItem.Object.ID)).Returns(nextStateItem.Object);
             database.Setup(x => x.GetItem(nextStateItem.Object.ID.ToString())).Returns(nextStateItem.Object);
 
-            ItemFactory.SetField(commandItem, FieldIDs.NextState, nextStateItem.Object.ID.ToString());
+            ItemFactory.SetIndexerField(commandItem, FieldIDs.NextState, nextStateItem.Object.ID.ToString());
 
             var actionItem = ItemFactory.CreateItem(database: database.Object);
             actionItem.Setup(x => x.Parent).Returns(commandItem.Object);

--- a/Test/UnitTest/Pipelines/ProfanityFilter/GetProfanityListFromItemFixture.cs
+++ b/Test/UnitTest/Pipelines/ProfanityFilter/GetProfanityListFromItemFixture.cs
@@ -1,0 +1,80 @@
+﻿using Moq;
+using NUnit.Framework;
+using Sitecore.Data;
+using Sitecore.Data.Fields;
+using Sitecore.Modules.WeBlog.Pipelines;
+using Sitecore.Modules.WeBlog.Pipelines.ProfanityFilter;
+
+namespace Sitecore.Modules.WeBlog.UnitTest.Pipelines.ProfanityFilter
+{
+    [TestFixture]
+    public class GetProfanityListFromItemFixture
+    {
+        [Test]
+        public void Process_UnknownItem_DoesNotPopulateWords()
+        {
+            // arrange
+            var database = Mock.Of<Database>();
+            var sut = new GetProfanityListFromItem(database);
+            var args = new ProfanityFilterArgs();
+
+            // act
+            sut.Process(args);
+
+            // assert
+            Assert.That(args.WordList, Is.Empty);
+        }
+
+
+        [Test]
+        public void Process_ValidItem_PopulatesWords()
+        {
+            // arrange
+            var database = new Mock<Database>();
+            var itemMock = ItemFactory.CreateItem(database: database.Object);
+            database.Setup(x => x.GetItem("item")).Returns(itemMock.Object);
+
+            var field = new Mock<Field>(ID.NewID, itemMock.Object);
+            field.Setup(x => x.Name).Returns(Constants.Fields.WordList);
+            field.Setup(x => x.Value).Returns("lorem\nipsum");
+
+            ItemFactory.AddFields(itemMock, new[] { field.Object });            
+
+            var sut = new GetProfanityListFromItem(database.Object);
+            sut.ItemPath = "item";
+            var args = new ProfanityFilterArgs();
+
+            // act
+            sut.Process(args);
+
+            // assert
+            Assert.That(args.WordList, Is.EquivalentTo(new[] { "lorem", "ipsum" }));
+        }
+
+        [Test]
+        public void Process_WordsAlreadyPopulated_DoesNothing()
+        {
+            // arrange
+            var database = new Mock<Database>();
+            var itemMock = ItemFactory.CreateItem(database: database.Object);
+            database.Setup(x => x.GetItem("item")).Returns(itemMock.Object);
+
+            var field = new Mock<Field>(ID.NewID, itemMock.Object);
+            field.Setup(x => x.Name).Returns(Constants.Fields.WordList);
+            field.Setup(x => x.Value).Returns("lorem\nipsum");
+
+            ItemFactory.AddFields(itemMock, new[] { field.Object });
+
+            var sut = new GetProfanityListFromItem(database.Object);
+            sut.ItemPath = "item";
+            var args = new ProfanityFilterArgs();
+            args.WordList = new[] { "dolor" };
+
+            // act
+            sut.Process(args);
+
+            // assert
+            Assert.That(args.WordList, Is.EquivalentTo(new[] { "dolor" }));
+        }
+    }
+}

--- a/Test/UnitTest/Workflow/ScribanMailActionFixture.cs
+++ b/Test/UnitTest/Workflow/ScribanMailActionFixture.cs
@@ -335,10 +335,10 @@ namespace Sitecore.Modules.WeBlog.UnitTest.Workflow
         private WorkflowPipelineArgs CreateWorkflowPipelineArgs(string to = "to@mail.com", string from = "from@mail.com", string subject = "subject", string message = "message")
         {
             var actionItemMock = ItemFactory.CreateItem();
-            ItemFactory.SetField(actionItemMock, "to", to);
-            ItemFactory.SetField(actionItemMock, "from", from);
-            ItemFactory.SetField(actionItemMock, "subject", subject);
-            ItemFactory.SetField(actionItemMock, "message", message);
+            ItemFactory.SetIndexerField(actionItemMock, "to", to);
+            ItemFactory.SetIndexerField(actionItemMock, "from", from);
+            ItemFactory.SetIndexerField(actionItemMock, "subject", subject);
+            ItemFactory.SetIndexerField(actionItemMock, "message", message);
 
             var dataItemMock = ItemFactory.CreateItem();
             var args = new WorkflowPipelineArgs(dataItemMock.Object, (StringDictionary)null, null);

--- a/src/Sitecore.Modules.WeBlog/Caching/ProfanityFilterCache.cs
+++ b/src/Sitecore.Modules.WeBlog/Caching/ProfanityFilterCache.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Sitecore.Caching;
+using Sitecore.Data;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,19 +8,36 @@ namespace Sitecore.Modules.WeBlog.Caching
 {
     public class ProfanityFilterCache : SimpleCache, IWeBlogCache
     {
-        public ProfanityFilterCache(string name, long maxSize) : base(name, maxSize) { }
+        private Database _database = null;
+
+        public ProfanityFilterCache(string name, long maxSize) : base(name, maxSize)
+        {
+            _database = ContentHelper.GetContentDatabase();
+        }
+
+        public ProfanityFilterCache(ICache innerCache, Database database) : base(innerCache)
+        {
+            _database = database ?? ContentHelper.GetContentDatabase();
+        }
 
         protected string CacheName
         {
-            get { return "wordlist_" + Context.Database.Name; }
+            get
+            {
+                var dbName = _database != null ? _database.Name : "nodb";
+                return "wordlist_" + dbName;
+            }
         }
 
-        public IEnumerable<string> WorList
+        [Obsolete("Use WordList property instead")]
+        public IEnumerable<string> WorList => WordList;
+
+        public IEnumerable<string> WordList
         {
             get
             {
                 var cachedList = Get(CacheName);
-                if (!String.IsNullOrEmpty(cachedList))
+                if (!string.IsNullOrEmpty(cachedList))
                 {
                     return cachedList.Split('|').ToList();
                 }
@@ -26,7 +45,7 @@ namespace Sitecore.Modules.WeBlog.Caching
             }
             set
             {
-                Set(CacheName, String.Join("|", value));
+                Set(CacheName, string.Join("|", value));
             }
         }
 

--- a/src/Sitecore.Modules.WeBlog/Caching/SimpleCache.cs
+++ b/src/Sitecore.Modules.WeBlog/Caching/SimpleCache.cs
@@ -6,6 +6,8 @@ namespace Sitecore.Modules.WeBlog.Caching
     {
         public SimpleCache(string name, long maxSize) : base(name, maxSize) { }
 
+        public SimpleCache(ICache innerCache) : base(innerCache) { }
+
         public string Get(string cacheKey)
         {
             return GetString(cacheKey);

--- a/src/Sitecore.Modules.WeBlog/Pipelines/ProfanityFilter/CacheProfanityList.cs
+++ b/src/Sitecore.Modules.WeBlog/Pipelines/ProfanityFilter/CacheProfanityList.cs
@@ -8,9 +8,9 @@ namespace Sitecore.Modules.WeBlog.Pipelines.ProfanityFilter
     {
         public void Process(ProfanityFilterArgs args)
         {
-            if (args.WordList.Any() && CacheManager.ProfanityFilterCache.WorList == null)
+            if (args.WordList.Any() && CacheManager.ProfanityFilterCache.WordList == null)
             {
-                CacheManager.ProfanityFilterCache.WorList = args.WordList;
+                CacheManager.ProfanityFilterCache.WordList = args.WordList;
             }
         }
     }

--- a/src/Sitecore.Modules.WeBlog/Pipelines/ProfanityFilter/GetProfanityListFromCache.cs
+++ b/src/Sitecore.Modules.WeBlog/Pipelines/ProfanityFilter/GetProfanityListFromCache.cs
@@ -6,9 +6,9 @@ namespace Sitecore.Modules.WeBlog.Pipelines.ProfanityFilter
     {
         public void Process(ProfanityFilterArgs args)
         {
-            if (CacheManager.ProfanityFilterCache.WorList != null)
+            if (CacheManager.ProfanityFilterCache.WordList != null)
             {
-                args.WordList = CacheManager.ProfanityFilterCache.WorList;
+                args.WordList = CacheManager.ProfanityFilterCache.WordList;
             }
         }
     }

--- a/src/Sitecore.Modules.WeBlog/Pipelines/ProfanityFilter/GetProfanityListFromItem.cs
+++ b/src/Sitecore.Modules.WeBlog/Pipelines/ProfanityFilter/GetProfanityListFromItem.cs
@@ -1,14 +1,21 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using Sitecore.Data;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Sitecore.Modules.WeBlog.Pipelines.ProfanityFilter
 {
     public class GetProfanityListFromItem : IProfanityFilterProcessor
     {
+        private Database _database = null;
+
         public string ItemPath { get; set; }
+
+        public GetProfanityListFromItem() : this(null) { }
+
+        public GetProfanityListFromItem(Database database)
+        {
+            _database = database ?? ContentHelper.GetContentDatabase();
+        }
 
         public void Process(ProfanityFilterArgs args)
         {
@@ -20,11 +27,11 @@ namespace Sitecore.Modules.WeBlog.Pipelines.ProfanityFilter
 
         private IEnumerable<string> GetProfanityItemContent()
         {
-            var item = Context.Database.GetItem(ItemPath);
+            var item = _database.GetItem(ItemPath);
             if (item != null)
             {
                 var field = item.Fields[Constants.Fields.WordList];
-                if (field != null && !String.IsNullOrEmpty(field.Value))
+                if (field != null && !string.IsNullOrEmpty(field.Value))
                 {
                     return field.Value.Split('\n').Select(s => s.Trim());
                 }


### PR DESCRIPTION
Use explicit content database, rather than context database for code invoked through WCF.